### PR TITLE
add libxml2 and serialbox and fix module bug

### DIFF
--- a/recipes/icon/25.2/gh200/config.yaml
+++ b/recipes/icon/25.2/gh200/config.yaml
@@ -1,6 +1,6 @@
 name: icon
 store: /user-environment
 spack:
-  commit: releases/v0.22
+  commit: v0.22.3
   repo: https://github.com/spack/spack.git
 description: Compilers and libraries required to build ICON

--- a/recipes/icon/25.2/gh200/environments.yaml
+++ b/recipes/icon/25.2/gh200/environments.yaml
@@ -10,6 +10,8 @@ icon:
   unify: true
   specs:
   - boost ~mpi
+  - libxml2
+  - serialbox@2.6.2%nvhpc +fortran
   - python@3.10
   - cuda@12.6
   - eccodes@2.36.4%nvhpc +tools +fortran +aec +openmp jp2k=jasper

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/missing_includes.patch
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/missing_includes.patch
@@ -1,0 +1,11 @@
+--- a/src/serialbox-c/FortranWrapper.cpp
++++ b/src/serialbox-c/FortranWrapper.cpp
+@@ -12,6 +12,8 @@
+  *
+ \*===------------------------------------------------------------------------------------------===*/
+ 
++#include <array>
++
+ #include "serialbox-c/FortranWrapper.h"
+ #include "serialbox-c/FieldMetainfo.h"
+ #include "serialbox-c/Metainfo.h"

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/bool_getters.patch
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/bool_getters.patch
@@ -1,0 +1,54 @@
+# This patch is applicable starting version 2.3.1
+--- a/src/serialbox-fortran/m_serialize.f90
++++ b/src/serialbox-fortran/m_serialize.f90
+@@ -634,11 +634,14 @@ SUBROUTINE fs_get_serializer_metainfo_b(serializer, key, val)
+        USE, INTRINSIC :: iso_c_binding
+        TYPE(C_PTR), INTENT(IN), VALUE                   :: serializer
+        CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: key
+-       LOGICAL, INTENT(OUT)                             :: val
++       INTEGER(KIND=C_INT), INTENT(OUT)                 :: val
+      END SUBROUTINE fs_get_serializer_metainfo_b_
+   END INTERFACE
+ 
+-  CALL fs_get_serializer_metainfo_b_(serializer%serializer_ptr, TRIM(key)//C_NULL_CHAR, val)
++  INTEGER(KIND=C_INT) :: c_val
++  CALL fs_get_serializer_metainfo_b_(serializer%serializer_ptr, TRIM(key)//C_NULL_CHAR, c_val)
++
++  val = c_val /= 0
+ END SUBROUTINE fs_get_serializer_metainfo_b
+ 
+ SUBROUTINE fs_get_serializer_metainfo_i(serializer, key, val)
+@@ -950,11 +953,14 @@ SUBROUTINE fs_get_field_metainfo_b(serializer, fieldname, key, val)
+        USE, INTRINSIC :: iso_c_binding
+        TYPE(C_PTR), INTENT(IN), VALUE                   :: serializer
+        CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: fieldname, key
+-       LOGICAL, INTENT(OUT)                             :: val
++       INTEGER(KIND=C_INT), INTENT(OUT)                 :: val
+      END SUBROUTINE fs_get_field_metainfo_b_
+   END INTERFACE
+ 
+-  CALL fs_get_field_metainfo_b_(serializer%serializer_ptr, TRIM(fieldname)//C_NULL_CHAR, TRIM(key)//C_NULL_CHAR, val)
++  INTEGER(KIND=C_INT) :: c_val
++  CALL fs_get_field_metainfo_b_(serializer%serializer_ptr, TRIM(fieldname)//C_NULL_CHAR, TRIM(key)//C_NULL_CHAR, c_val)
++
++  val = c_val /= 0
+ END SUBROUTINE fs_get_field_metainfo_b
+ 
+ SUBROUTINE fs_get_field_metainfo_i(serializer, fieldname, key, val)
+@@ -1466,11 +1472,14 @@ SUBROUTINE fs_get_savepoint_metainfo_b(savepoint, key, val)
+        USE, INTRINSIC :: iso_c_binding
+        TYPE(C_PTR), INTENT(IN), VALUE                   :: savepoint
+        CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: key
+-       LOGICAL, INTENT(OUT)                             :: val
++       INTEGER(KIND=C_INT), INTENT(OUT)                 :: val
+      END SUBROUTINE fs_get_savepoint_metainfo_b_
+   END INTERFACE
+ 
+-  CALL fs_get_savepoint_metainfo_b_(savepoint%savepoint_ptr, TRIM(key)//C_NULL_CHAR, val)
++  INTEGER(KIND=C_INT) :: c_val
++  CALL fs_get_savepoint_metainfo_b_(savepoint%savepoint_ptr, TRIM(key)//C_NULL_CHAR, c_val)
++
++  val = c_val /= 0
+ END SUBROUTINE fs_get_savepoint_metainfo_b
+ 
+ SUBROUTINE fs_get_savepoint_metainfo_i(savepoint, key, val)

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/examples.patch
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/examples.patch
@@ -1,0 +1,27 @@
+# This patch is applicable starting version 2.3.1
+--- a/examples/fortran/simple/m_ser.F90
++++ b/examples/fortran/simple/m_ser.F90
+@@ -38 +38 @@ USE utils_ppser, ONLY:  &
+-    REAL(KIND=8), DIMENSION(:,:,:) :: a
++    REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(:,:,:) :: a
+@@ -59 +59 @@ USE utils_ppser, ONLY:  &
+-    REAL(KIND=8), DIMENSION(:,:,:) :: a
++    REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(:,:,:) :: a
+@@ -91,2 +91,2 @@ USE utils_ppser, ONLY:  &
+-    REAL(KIND=8), DIMENSION(:,:,:) :: a
+-    REAL(KIND=8) :: rprecision
++    REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(:,:,:) :: a
++    REAL(KIND=SELECTED_REAL_KIND(15)) :: rprecision
+@@ -97 +97 @@ USE utils_ppser, ONLY:  &
+-          prefix_ref='SerialboxTest',rprecision=rprecision,rperturb=1.0e-5_8)
++          prefix_ref='SerialboxTest',rprecision=rprecision,rperturb=REAL(1.0e-5,SELECTED_REAL_KIND(15)))
+--- a/examples/fortran/simple/main_consumer.F90
++++ b/examples/fortran/simple/main_consumer.F90
+@@ -14 +14 @@ PROGRAM main_consumer
+-  REAL(KIND=8), DIMENSION(5,5,5) :: a
++  REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(5,5,5) :: a
+--- a/examples/fortran/simple/main_producer.F90
++++ b/examples/fortran/simple/main_producer.F90
+@@ -14 +14 @@ PROGRAM main_producer
+-  REAL(KIND=8), DIMENSION(5,5,5) :: a
++  REAL(KIND=SELECTED_REAL_KIND(15)), DIMENSION(5,5,5) :: a

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/ftg.patch
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/ftg.patch
@@ -1,0 +1,31 @@
+# This patch is applicable starting version 2.3.1
+--- a/src/serialbox-fortran/m_ser_ftg.f90
++++ b/src/serialbox-fortran/m_ser_ftg.f90
+@@ -822,5 +822,5 @@ SUBROUTINE ftg_write_logical_1d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 
+@@ -853,5 +853,5 @@ SUBROUTINE ftg_write_logical_2d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 
+@@ -886,5 +886,5 @@ SUBROUTINE ftg_write_logical_3d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 
+@@ -919,5 +919,5 @@ SUBROUTINE ftg_write_logical_4d(fieldname, field, lbounds, ubounds)
+       CALL ftg_register_only_internal(fieldname, 'bool', fs_boolsize(), lbounds, ubounds)
+     END IF
+-    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', TRIM(ADJUSTL(ftg_loc_hex(C_LOC(field)))))
++    CALL ftg_add_field_metainfo(TRIM(fieldname), 'ftg:loc', 'N/A')
+   END IF
+ 

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/interface.patch
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/nag/interface.patch
@@ -1,0 +1,9 @@
+# This patch is applicable starting version 2.0.1
+--- a/src/serialbox-fortran/utils_ppser.f90
++++ b/src/serialbox-fortran/utils_ppser.f90
+@@ -33 +33 @@ MODULE utils_ppser
+-USE iso_fortran_env
++USE f90_unix_proc; USE iso_fortran_env
+@@ -66 +66 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
+-  REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
++  REAL(KIND=SELECTED_REAL_KIND(15)), OPTIONAL, INTENT(IN)     :: rprecision, rperturb

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/package.py
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/package.py
@@ -1,0 +1,189 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class Serialbox(CMakePackage):
+    """Serialbox is a serialization library and tools for C/C++, Python3 and
+    Fortran. Serialbox is used in several projects for building validation
+    frameworks against reference runs."""
+
+    homepage = "https://github.com/GridTools/serialbox"
+    url = "https://github.com/GridTools/serialbox/archive/v2.6.1.tar.gz"
+
+    maintainers("skosukhin")
+
+    license("BSD-2-Clause")
+
+    version("2.6.2", sha256="d1b4c79078e3b1d4a45b7b024eb647d21873498ac666e41a5ee8b8e13c95a7ac")
+    version("2.6.1", sha256="b795ce576e8c4fd137e48e502b07b136079c595c82c660cfa2e284b0ef873342")
+    version("2.6.0", sha256="9199f8637afbd7f2b3c5ba932d1c63e9e14d553a0cafe6c29107df0e04ee9fae")
+    version("2.5.4", sha256="f4aee8ef284f58e6847968fe4620e222ac7019d805bbbb26c199e4b6a5094fee")
+    version("2.5.3", sha256="696499b3f43978238c3bcc8f9de50bce2630c07971c47c9e03af0324652b2d5d")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    variant("c", default=True, description="enable C interface")
+    variant("python", default=False, description="enable Python interface")
+    variant("fortran", default=False, description="enable Fortran interface")
+    variant("ftg", default=False, description="enable FortranTestGenerator frontend")
+    variant("sdb", default=False, description="enable stencil debugger")
+    variant("shared", default=True, description="build shared libraries")
+    variant("examples", default=False, description="build the examples")
+    variant("logging", default=True, description="enable the logging infrastructure")
+    variant("async-api", default=True, description="enable the asynchronous API")
+    variant("netcdf", default=False, description="build the NetCDF archive backend")
+    variant(
+        "std-filesystem",
+        default=True,
+        description="use std::experimental::filesystem (no dependency on " "compiled boost libs)",
+    )
+
+    depends_on("cmake@3.12:", type="build")
+
+    depends_on("boost@1.54:", type="build")
+    depends_on("boost+filesystem+system", when="~std-filesystem", type=("build", "link"))
+
+    depends_on("netcdf-c", when="+netcdf")
+
+    # The preprocessor can be run with Python 2:
+    depends_on("python", type="run")
+    # The Python interface is compatible only with Python 3:
+    depends_on("python@3.4:", when="+python", type=("build", "run"))
+    depends_on("py-numpy", when="+python", type=("build", "run"))
+
+    # pp_ser fails to process source files containing Unicode character with
+    # Python 3 (https://github.com/GridTools/serialbox/pull/249):
+    patch("ppser_py3.patch", when="@2.2.0:")
+
+    # NAG patches:
+    patch("nag/interface.patch", when="@2.0.1:+fortran%nag")
+    patch("nag/examples.patch", when="@2.3.1:+fortran+examples%nag")
+    patch("nag/ftg.patch", when="@2.3.1:+ftg%nag")
+    patch("nag/bool_getters.patch", when="@2.3.1:+fortran%nag@7.1:")
+
+    # Add missing include directives
+    # (part of https://github.com/GridTools/serialbox/pull/259):
+    patch("missing_includes.patch", when="@:2.6.1+c")
+
+    conflicts(
+        "+ftg",
+        when="~fortran",
+        msg="the FortranTestGenerator frontend requires the Fortran " "interface",
+    )
+    conflicts(
+        "+ftg",
+        when="@:2.2.999",
+        msg="the FortranTestGenerator frontend is supported only " "starting version 2.3.0",
+    )
+    conflicts("+sdb", when="~python", msg="the stencil debugger requires the Python interface")
+    conflicts("+fortran", when="~c", msg="the Fortran interface requires the C interface")
+    conflicts("+python", when="~c", msg="the Python interface requires the C interface")
+    conflicts("+python", when="~shared", msg="the Python interface requires the shared libraries")
+
+    def patch(self):
+        # The following is implemented as a method to avoid having two sets of
+        # almost identical patch files: one with the CR symbols (for versions
+        # 2.5.x) and one without them (for versions 2.6.x).
+
+        # Remove hard-coded -march=native
+        # (see https://github.com/GridTools/serialbox/pull/233):
+        if self.spec.satisfies("@2.0.1:2.6.0"):
+            filter_file(r"^(\s*set\(CMAKE_CXX_FLAGS.*-march=native)", r"#\1", "CMakeLists.txt")
+
+        # Do not fallback to boost::filesystem:
+        if "+std-filesystem" in self.spec:
+            filter_file(
+                r"(message\()" r'STATUS( "std::experimental::filesystem not found).*("\))',
+                r"\1FATAL_ERROR\2\3",
+                "CMakeLists.txt",
+            )
+
+    @property
+    def libs(self):
+        query_parameters = self.spec.last_query.extra_parameters
+
+        shared = "+shared" in self.spec
+
+        query2libraries = {
+            tuple(): ["libSerialboxCore"],
+            ("c", "fortran"): ["libSerialboxFortran", "libSerialboxC", "libSerialboxCore"],
+            ("c",): ["libSerialboxC", "libSerialboxCore"],
+            ("fortran",): ["libSerialboxFortran", "libSerialboxC", "libSerialboxCore"],
+        }
+
+        key = tuple(sorted(query_parameters))
+        libraries = query2libraries[key]
+
+        if self.spec.satisfies("@2.5.0:2.5"):
+            libraries = [
+                "{0}{1}".format(name, "Shared" if shared else "Static") for name in libraries
+            ]
+
+        libs = find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+
+        if libs:
+            return libs
+
+        msg = "Unable to recursively locate {0} libraries in {1}"
+        raise NoLibrariesError(msg.format(self.spec.name, self.spec.prefix))
+
+    def flag_handler(self, name, flags):
+        cmake_flags = []
+
+        if name == "cxxflags":
+            # Intel (at least up to version 19.0.1, version 19.0.4 works) and
+            # PGI (at least up to version 19.9, version 20.1.0 works) compilers
+            # have problems with C++11 name mangling. An attempt to link to
+            # libSerialboxCore leads to:
+            # undefined reference to
+            #     `std::experimental::filesystem::v1::__cxx11::path::
+            #         _M_find_extension[abi:cxx11]() const'
+            if self.spec.satisfies("+std-filesystem%intel@:19.0.1"):
+                cmake_flags.append("-D_GLIBCXX_USE_CXX11_ABI=0")
+
+        return flags, None, (cmake_flags or None)
+
+    def setup_run_environment(self, env):
+        # Allow for running the preprocessor directly:
+        env.prepend_path("PATH", self.prefix.python.pp_ser)
+        # Allow for running the preprocessor as a Python module, as well as
+        # enable the Python interface in a non-standard directory:
+        env.prepend_path("PYTHONPATH", self.prefix.python.pp_ser)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        # Simplify the location of the preprocessor by dependent packages:
+        self.spec.pp_ser = join_path(self.prefix.python.pp_ser, "pp_ser.py")
+
+    def cmake_args(self):
+        args = [
+            "-DBOOST_ROOT:PATH=%s" % self.spec["boost"].prefix,
+            # https://cmake.org/cmake/help/v3.15/module/FindBoost.html#boost-cmake
+            self.define("Boost_NO_BOOST_CMAKE", True),
+            self.define_from_variant("SERIALBOX_ENABLE_C", "c"),
+            self.define_from_variant("SERIALBOX_ENABLE_PYTHON", "python"),
+            self.define_from_variant("SERIALBOX_ENABLE_FORTRAN", "fortran"),
+            self.define_from_variant("SERIALBOX_ENABLE_FTG", "ftg"),
+            self.define_from_variant("SERIALBOX_ENABLE_SDB", "sdb"),
+            self.define_from_variant("SERIALBOX_BUILD_SHARED", "shared"),
+            self.define_from_variant("SERIALBOX_EXAMPLES", "examples"),
+            self.define_from_variant("SERIALBOX_LOGGING", "logging"),
+            self.define_from_variant("SERIALBOX_ASYNC_API", "async-api"),
+            # CMake scripts of Serialbox (at least up to version 2.6.0) are
+            # broken and do not instruct the compiler to link to the OpenSSL
+            # libraries:
+            self.define("SERIALBOX_USE_OPENSSL", False),
+            self.define_from_variant("SERIALBOX_ENABLE_EXPERIMENTAL_FILESYSTEM", "std-filesystem"),
+            self.define_from_variant("SERIALBOX_USE_NETCDF", "netcdf"),
+            self.define("SERIALBOX_TESTING", self.run_tests),
+        ]
+
+        if "+netcdf" in self.spec:
+            args.append("-DNETCDF_ROOT:PATH=%s" % self.spec["netcdf-c"].prefix)
+
+        return args

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/ppser_py3.patch
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/ppser_py3.patch
@@ -1,0 +1,48 @@
+# This patch is applicable starting version 2.2.0
+--- a/src/serialbox-python/pp_ser/pp_ser.py
++++ b/src/serialbox-python/pp_ser/pp_ser.py
+@@ -51 +51 @@ __email__ = 'oliver.fuhrer@meteoswiss.ch'
+-def to_ascii(text):
++def open23(name, mode='r'):
+@@ -53 +53,10 @@ def to_ascii(text):
+-        return bytes(text, 'ascii')
++        return open(name, mode,
++                    encoding=(None if 'b' in mode else 'UTF-8'),
++                    errors=(None if 'b' in mode else 'surrogateescape'))
++    else:
++        return open(name, mode)
++
++
++def bytes23(text):
++    if sys.version_info[0] == 3:
++        return bytes(text, 'UTF-8', 'surrogateescape')
+@@ -57,0 +67,11 @@ def to_ascii(text):
++def getline(filename, lineno):
++    try:
++        return linecache.getline(filename, lineno)
++    except:
++        with open23(filename, 'r') as f:
++            for i, line in enumerate(f, start=1):
++                if i == lineno:
++                    return line
++            return ''
++
++
+@@ -608 +628 @@ class PpSer:
+-            nextline = linecache.getline(os.path.join(self.infile), lookahead_index)
++            nextline = getline(os.path.join(self.infile), lookahead_index)
+@@ -613 +633 @@ class PpSer:
+-                nextline = linecache.getline(os.path.join(self.infile), lookahead_index)
++                nextline = getline(os.path.join(self.infile), lookahead_index)
+@@ -711 +731 @@ class PpSer:
+-                nextline = linecache.getline(os.path.join(self.infile), lookahead_index)
++                nextline = getline(os.path.join(self.infile), lookahead_index)
+@@ -716 +736 @@ class PpSer:
+-                        nextline = linecache.getline(os.path.join(self.infile), lookahead_index)
++                        nextline = getline(os.path.join(self.infile), lookahead_index)
+@@ -803 +823 @@ class PpSer:
+-        input_file = open(os.path.join(self.infile), 'r')
++        input_file = open23(os.path.join(self.infile), 'r')
+@@ -843 +863 @@ class PpSer:
+-            output_file.write(to_ascii(self.__outputBuffer))
++            output_file.write(bytes23(self.__outputBuffer))

--- a/recipes/icon/25.2/gh200/repo/packages/serialbox/readme.md
+++ b/recipes/icon/25.2/gh200/repo/packages/serialbox/readme.md
@@ -1,0 +1,2 @@
+copied March 28 2025 from mainline spack (commit 2f3ef790e2ac4d515fa8694874e646ee09e1c42a) in order to get version 2.6.2
+


### PR DESCRIPTION
- add libxml2 to the default view
- add the serialbox package from the last spack main to fix issue with recent nvhpc compiler
- use spack v0.22.3 instead of release/0.22 in order to fix modules issues