### PR TITLE
[fdb] update FDB version to 5.17.3 and enable GRIBJUMP plugin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,11 @@ uenvs:
         zen2: '5.16'
         zen3: '5.16'
       develop: False
+    "5.17":
+      recipes:
+        zen2: '5.17'
+        zen3: '5.17'
+      develop: False
   icon:
     "25.2":
       recipes:

--- a/recipes/fdb/5.16/post-install
+++ b/recipes/fdb/5.16/post-install
@@ -32,4 +32,5 @@ jq '.views.fdb.env.values.list.FDB_HOME = [{"op":"prepend","value":["/user-envir
 jq '.views.fdb.env.values.list.GRIB_DEFINITION_PATH = [{"op":"prepend","value":["/user-environment/data/share/eccodes-cosmo-mars/definitions", "/user-environment/data/share/definitions.edzw-2.38.3-1","/user-environment/env/fdb/share/eccodes/definitions"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.FDB5_CONFIG_FILE = [{"op":"prepend","value":["/user-environment/meta/recipe/meta/private/fdb_realtime_config.yaml"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.PATH[0].value |= ["/user-environment/venvs/fdb/bin/"] + .' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.FDB_ENABLE_GRIBJUMP = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 

--- a/recipes/fdb/5.16/post-install
+++ b/recipes/fdb/5.16/post-install
@@ -32,6 +32,3 @@ jq '.views.fdb.env.values.list.FDB_HOME = [{"op":"prepend","value":["/user-envir
 jq '.views.fdb.env.values.list.GRIB_DEFINITION_PATH = [{"op":"prepend","value":["/user-environment/data/share/eccodes-cosmo-mars/definitions", "/user-environment/data/share/definitions.edzw-2.38.3-1","/user-environment/env/fdb/share/eccodes/definitions"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.FDB5_CONFIG_FILE = [{"op":"prepend","value":["/user-environment/meta/recipe/meta/private/fdb_realtime_config.yaml"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.PATH[0].value |= ["/user-environment/venvs/fdb/bin/"] + .' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
-jq '.views.fdb.env.values.list.FDB_ENABLE_GRIBJUMP = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
-jq '.views.fdb.env.values.list.AUTO_LOAD_PLUGINS = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
-jq '.views.fdb.env.values.list.ECKIT_HOME = [{"op":"prepend","value":["/user-environment/env/fdb/"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json

--- a/recipes/fdb/5.16/post-install
+++ b/recipes/fdb/5.16/post-install
@@ -34,4 +34,4 @@ jq '.views.fdb.env.values.list.FDB5_CONFIG_FILE = [{"op":"prepend","value":["/us
 jq '.views.fdb.env.values.list.PATH[0].value |= ["/user-environment/venvs/fdb/bin/"] + .' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.FDB_ENABLE_GRIBJUMP = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.AUTO_LOAD_PLUGINS = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
-
+jq '.views.fdb.env.values.list.ECKIT_HOME = [{"op":"prepend","value":["/user-environment/env/fdb/"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json

--- a/recipes/fdb/5.16/post-install
+++ b/recipes/fdb/5.16/post-install
@@ -33,4 +33,5 @@ jq '.views.fdb.env.values.list.GRIB_DEFINITION_PATH = [{"op":"prepend","value":[
 jq '.views.fdb.env.values.list.FDB5_CONFIG_FILE = [{"op":"prepend","value":["/user-environment/meta/recipe/meta/private/fdb_realtime_config.yaml"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.PATH[0].value |= ["/user-environment/venvs/fdb/bin/"] + .' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 jq '.views.fdb.env.values.list.FDB_ENABLE_GRIBJUMP = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.AUTO_LOAD_PLUGINS = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
 

--- a/recipes/fdb/5.17/compilers.yaml
+++ b/recipes/fdb/5.17/compilers.yaml
@@ -1,0 +1,5 @@
+bootstrap:
+  spec: gcc@11.3
+gcc:
+  specs:
+  - gcc@13.3

--- a/recipes/fdb/5.17/config.yaml
+++ b/recipes/fdb/5.17/config.yaml
@@ -1,0 +1,6 @@
+name: fdb
+store: /user-environment
+spack:
+  commit: releases/v0.23
+  repo: https://github.com/spack/spack.git
+description: MCH FDB uenv 

--- a/recipes/fdb/5.17/environments.yaml
+++ b/recipes/fdb/5.17/environments.yaml
@@ -1,0 +1,23 @@
+fdb:
+  compiler:
+    - toolchain: gcc
+      spec: gcc@13.3
+  unify: when_possible
+  mpi: null
+  packages: []
+  specs:
+  - fdb@=5.17.3
+  - gribjump@=0.10.0
+  - eckit@=1.28.8 linalg=none
+  - metkit@=1.11.22
+  - eccodes@=2.38.3 jp2k=none ~fortran +pthreads +memfs +aec
+  - ecbuild@=3.10.0
+  - python@=3.11.6
+  variants:
+  - ~mpi
+  views:
+    fdb:
+      link: roots
+      uenv:
+        prefix_paths:
+          LD_LIBRARY_PATH: [lib, lib64]

--- a/recipes/fdb/5.17/meta/private/expand_params.py
+++ b/recipes/fdb/5.17/meta/private/expand_params.py
@@ -1,0 +1,49 @@
+import argparse
+import re 
+import yaml 
+
+def parse_file(filepath):
+    entries = {}
+
+    with open(filepath, 'r') as file:
+        lines = file.readlines()
+
+    for i in range(len(lines)):
+        # Look for lines with paramId
+        param_match = re.match(r"#paramId:\s*(\d+)", lines[i])
+        if param_match:
+            param_id = param_match.group(1)
+            description = lines[i + 1].strip().lstrip("#").strip()
+            key_match = re.match(r"'([^']+)'", lines[i + 2])
+            key = key_match.group(1) if key_match else ""
+            entries[param_id] = ((key, description))
+
+    return entries
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process two filenames.")
+    parser.add_argument("paramids", type=str, help="Path to the first file")
+    parser.add_argument("paramdefs", type=str, help="Path to the second file")
+    
+    args = parser.parse_args()
+
+    # Convert the comma-separated string into a list
+    paramdef_list = args.paramdefs.split(',')
+
+    with open(args.paramids, 'r') as file:
+        metkit_params = yaml.safe_load(file)
+
+    for paramdef in paramdef_list:
+
+        icon_params = parse_file(paramdef)
+
+        for key in icon_params:
+            if int(key) not in metkit_params:
+                metkit_params[int(key)] = list(s.lower() for s in icon_params[key]) 
+
+    with open(args.paramids, 'w') as file:
+        yaml.dump(metkit_params, file, sort_keys=True, default_flow_style=False, allow_unicode=True)
+
+if __name__ == "__main__":
+    main()

--- a/recipes/fdb/5.17/meta/private/fdb_realtime_config.yaml
+++ b/recipes/fdb/5.17/meta/private/fdb_realtime_config.yaml
@@ -1,0 +1,8 @@
+---
+type: local
+engine: toc
+schema: /scratch/mch/trajond/fdb-realtime-lcm/schema
+spaces:
+- handler: Default
+  roots:
+  - path: /scratch/mch/trajond/fdb-root-realtime

--- a/recipes/fdb/5.17/meta/private/metkit_language.yaml.patch
+++ b/recipes/fdb/5.17/meta/private/metkit_language.yaml.patch
@@ -1,0 +1,19 @@
+--- language.yaml       2025-05-22 14:09:42.000000000 +0200
++++ language_new.yaml   2025-05-22 14:09:26.000000000 +0200
+@@ -89,6 +89,7 @@
+     flatten: false
+     type: enum
+     values:
++    - [ememb, whatever]
+     - [3g, 3d variational gradients]
+     - [3v, 3d variational analysis]
+     - [4g, 4d variational gradients]
+@@ -601,7 +602,7 @@
+     - ensemble
+     by: 1
+     only:
+-    - type: [pf, cr, cm, fcmean, fcmin, fcmax, fcstdev, sot, fc, wp, 4i, 4v]
++    - type: [pf, cr, cm, fcmean, fcmin, fcmax, fcstdev, sot, fc, wp, 4i, 4v, ememb]
+     never:
+     # This is to prevent number with type=fc and stream=oper
+     - stream: [oper, wave]

--- a/recipes/fdb/5.17/meta/private/pyproject.toml
+++ b/recipes/fdb/5.17/meta/private/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.poetry]
+name = "nwp-demo"
+# Keep only Major and Minor version in this configuration,
+# the patch version is calculated when releasing the library
+version = "1.0"
+description = "Demo scripts and notebooks for reading and processing forecast data using Polytope."
+authors = ["MeteoSwiss"]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "~3.11"
+meteodata-lab = {version = "*", extras = ["polytope", "regrid"] }
+# version > 0.1.1 of pyfdb requires eccodes >= 2.39
+pyfdb = "0.1.1"
+fdb-utils = { git = "https://github.com/MeteoSwiss/fdb-utils.git", tag = "v1.1.3"}
+ipykernel = "*"
+earthkit-plots = "*"
+earthkit-geo = "*"
+earthkit-meteo = "*"
+pygribjump = { git = "https://github.com/ecmwf/gribjump.git", tag = "0.10.0" }
+nbconvert = "*"
+pyyaml = "*"
+
+[tool.pytest.ini_options]
+testpaths = ["test"]
+pythonpath = "."
+
+[tool.yapf]
+based_on_style = "pep8"
+column_limit = "120"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/recipes/fdb/5.17/post-install
+++ b/recipes/fdb/5.17/post-install
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e 
+rm -rf /user-environment/data/share
+mkdir -p /user-environment/data/share
+pushd /user-environment/data/share
+wget https://opendata.dwd.de/weather/lib/grib/eccodes_definitions.edzw-2.38.3-1.tar.bz2
+bunzip2  eccodes_definitions.edzw-2.38.3-1.tar.bz2
+tar xvf eccodes_definitions.edzw-2.38.3-1.tar
+rm eccodes_definitions.edzw-2.38.3-1.tar
+git clone -b v0.0.2 https://github.com/MeteoSwiss/eccodes-cosmo-mars.git
+popd
+
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/user-environment /user-environment/env/fdb/bin/python3.11 -
+
+pushd /user-environment/meta/recipe/meta/private/
+rm -rf  /user-environment/venvs/
+mkdir -p /user-environment/venvs/
+/user-environment/env/fdb/bin/python3.11 -m venv /user-environment/venvs/fdb
+source /user-environment/venvs/fdb/bin/activate
+/user-environment/bin/poetry install
+popd
+
+patch_dir=$(dirname $(find /user-environment/linux-sles15-zen3/gcc-13.3.0/ -name language.yaml))
+set +e
+patch -d ${patch_dir} -i /user-environment/meta/recipe/meta/private/metkit_language.yaml.patch
+set -e
+
+python /user-environment/meta/recipe/meta/private/expand_params.py ${patch_dir}/paramids.yaml /user-environment/data/share/definitions.edzw-2.38.3-1/grib2/shortName.def,/user-environment/data/share/definitions.edzw-2.38.3-1/grib2/localConcepts/edzw/shortName.def
+
+jq '.views.fdb.env.values.list.FDB5_HOME = [{"op":"prepend","value":["/user-environment/env/fdb/bin"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.GRIB_DEFINITION_PATH = [{"op":"prepend","value":["/user-environment/data/share/eccodes-cosmo-mars/definitions", "/user-environment/data/share/definitions.edzw-2.38.3-1","/user-environment/env/fdb/share/eccodes/definitions"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.FDB5_CONFIG_FILE = [{"op":"prepend","value":["/user-environment/meta/recipe/meta/private/fdb_realtime_config.yaml"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.PATH[0].value |= ["/user-environment/venvs/fdb/bin/"] + .' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.FDB_ENABLE_GRIBJUMP = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.AUTO_LOAD_PLUGINS = [{"op":"set","value":"1"}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json
+jq '.views.fdb.env.values.list.ECKIT_HOME = [{"op":"prepend","value":["/user-environment/env/fdb/"]}]' store/meta/env.json > tmp.json && mv tmp.json store/meta/env.json

--- a/recipes/fdb/5.17/repo/packages/ecbuild/package.py
+++ b/recipes/fdb/5.17/repo/packages/ecbuild/package.py
@@ -1,0 +1,49 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Ecbuild(CMakePackage):
+    """ecBuild is the ECMWF build system. It is built on top of CMake and
+    consists of a set of macros as well as a wrapper around CMake"""
+
+    homepage = "https://github.com/ecmwf/ecbuild"
+    url = "https://github.com/ecmwf/ecbuild/archive/refs/tags/3.6.1.tar.gz"
+
+    maintainers("skosukhin", "climbfuji", "victoria-cherkas", "dominichofer")
+
+    license("Apache-2.0")
+
+    version("3.10.0", sha256="7065e1725584b507517cbfc456299ff588e20adf37bc6210ce89fb65a1ad08d0") 
+    version("3.9.0", sha256="8ad20169a7d917d6ac81a7ca0d1b11616e2aeb82c7782f6ae5b768603a3e000a") 
+    version("3.7.2", sha256="7a2d192cef1e53dc5431a688b2e316251b017d25808190faed485903594a3fb9")
+    version("3.6.5", sha256="98bff3d3c269f973f4bfbe29b4de834cd1d43f15b1c8d1941ee2bfe15e3d4f7f")
+    version("3.6.1", sha256="796ccceeb7af01938c2f74eab0724b228e9bf1978e32484aa3e227510f69ac59")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    depends_on("cmake@3.11:", type=("build", "run"))
+
+    # See https://github.com/ecmwf/ecbuild/issues/35
+    depends_on("cmake@:3.19", type=("build", "run"), when="@:3.6.1")
+
+    # Some of the installed scripts require running Perl:
+    depends_on("perl", type=("build", "run"))
+
+    variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
+
+    @when("+fismahigh")
+    def patch(self):
+        filter_file('ssh://[^"]+', "", "cmake/compat/ecmwf_git.cmake")
+        filter_file('https?://[^"]+', "", "cmake/compat/ecmwf_git.cmake")
+        filter_file(
+            "https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_check_urls.cmake"
+        )
+        filter_file(
+            "https?://.*test-data", "DISABLED_BY_DEFAULT", "cmake/ecbuild_get_test_data.cmake"
+        )

--- a/recipes/fdb/5.17/repo/packages/eccodes/cmake_install_rpath.patch
+++ b/recipes/fdb/5.17/repo/packages/eccodes/cmake_install_rpath.patch
@@ -1,0 +1,11 @@
+--- a/cmake/ecbuild_append_to_rpath.cmake
++++ b/cmake/ecbuild_append_to_rpath.cmake
+@@ -31,7 +31,7 @@ function( _path_append var path )
+ 	else()
+ 		list( FIND ${var} ${path} _found )
+ 		if( _found EQUAL "-1" )
+-			set( ${var} "${${var}}:${path}" PARENT_SCOPE )
++			set( ${var} "${${var}};${path}" PARENT_SCOPE )
+ 		endif()
+ 	endif()
+ endfunction()

--- a/recipes/fdb/5.17/repo/packages/eccodes/openjpeg_jasper.patch
+++ b/recipes/fdb/5.17/repo/packages/eccodes/openjpeg_jasper.patch
@@ -1,0 +1,39 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,6 +43,18 @@ ecbuild_add_option( FEATURE JPG
+     DESCRIPTION "support for JPG decoding/encoding"
+     DEFAULT ON
+ )
++# Options related to JPG. The Jasper and OpenJPEG libraries
++ecbuild_add_option( FEATURE JPG_LIBJASPER
++    DESCRIPTION "Support for JPG decoding/encoding with the Jasper library"
++    CONDITION ENABLE_JPG
++    DEFAULT ON
++)
++ecbuild_add_option( FEATURE JPG_LIBOPENJPEG
++    DESCRIPTION "Support for JPG decoding/encoding with the OpenJPEG library"
++    CONDITION ENABLE_JPG
++    DEFAULT ON
++)
++
+ 
+ ecbuild_add_option( FEATURE PNG
+     DESCRIPTION "support for PNG decoding/encoding"
+@@ -144,7 +156,7 @@ if( ENABLE_JPG )
+ 
+     find_package( OpenJPEG )
+ 
+-    if( JASPER_FOUND )
++    if( JASPER_FOUND AND ENABLE_JPG_LIBJASPER )
+         list( APPEND ECCODES_TPLS Jasper )
+         set( HAVE_JPEG 1 )
+         set( HAVE_LIBJASPER 1 )
+@@ -152,7 +164,7 @@ if( ENABLE_JPG )
+         string(REGEX REPLACE "^([0-9]+)\\.[0-9]+\\.[0-9]+.*" "\\1" JASPER_VERSION_MAJOR "${JASPER_VERSION_STRING}")
+     endif()
+ 
+-    if( OPENJPEG_FOUND )
++    if( OPENJPEG_FOUND AND ENABLE_JPG_LIBOPENJPEG )
+         list( APPEND ECCODES_TPLS OpenJPEG )
+         set( HAVE_JPEG 1 )
+         set( HAVE_LIBOPENJPEG 1 )

--- a/recipes/fdb/5.17/repo/packages/eccodes/package.py
+++ b/recipes/fdb/5.17/repo/packages/eccodes/package.py
@@ -1,0 +1,373 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+_definitions = {
+    # German Meteorological Service (Deutscher Wetterdienst, DWD):
+    "edzw": {
+        "conflicts": {"when": "@:2.19.1,2.22.0,2.24.0:"},
+        "resources": [
+            {
+                "when": "@2.20.0",
+                "url": "http://opendata.dwd.de/weather/lib/grib/eccodes_definitions.edzw-2.20.0-1.tar.gz",
+                "sha256": "a92932f8a13c33cba65d3a33aa06c7fb4a37ed12a78e9abe2c5e966402b99af4",
+            },
+            {
+                "when": "@2.21.0",
+                "url": "http://opendata.dwd.de/weather/lib/grib/eccodes_definitions.edzw-2.21.0-3.tar.bz2",
+                "sha256": "046f1f6450abb3b44c31dee6229f4aab06ca0d3576e27e93e05ccb7cd6e2d9d9",
+            },
+            {
+                "when": "@2.22.1",
+                "url": "http://opendata.dwd.de/weather/lib/grib/eccodes_definitions.edzw-2.22.1-1.tar.bz2",
+                "sha256": "be73102a0dcabb236bacd2a70c7b5475f673fda91b49e34df61bef0fa5ad3389",
+            },
+            {
+                "when": "@2.23.0",
+                "url": "http://opendata.dwd.de/weather/lib/grib/eccodes_definitions.edzw-2.23.0-4.tar.bz2",
+                "sha256": "c5db32861c7d23410aed466ffef3ca661410d252870a3949442d3ecb176aa338",
+            },
+        ],
+    }
+}
+
+
+class Eccodes(CMakePackage):
+    """ecCodes is a package developed by ECMWF for processing meteorological
+    data in GRIB (1/2), BUFR (3/4) and GTS header formats."""
+
+    homepage = "https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home"
+    url = "https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.2.0-Source.tar.gz?api=v2"
+    git = "https://github.com/ecmwf/eccodes.git"
+    list_url = "https://confluence.ecmwf.int/display/ECC/Releases"
+
+    maintainers("skosukhin", "victoria-cherkas", "climbfuji")
+
+    license("Apache-2.0")
+
+    version("develop", branch="develop")
+
+    version("2.38.3", sha256="fa7b7ffb22973ed1dfbeb208c042a67a805ab070f1288a0f1f0707a1020d1c81")
+    version("2.38.2", sha256="b4ce8bd144ac957c7650e7013d3502573120502158cd03b8915bab83d3c52e9d")
+    version("2.38.0", sha256="96a21fbe8ca3aa4c31bb71bbd378b7fd130cbc0f7a477567d70e66a000ff68d9")
+    version("2.34.0", sha256="3cd208c8ddad132789662cf8f67a9405514bfefcacac403c0d8c84507f303aba")
+    version("2.33.0", sha256="bdcec8ce63654ec6803400c507f01220a9aa403a45fa6b5bdff7fdcc44fd7daf")
+    version("2.32.1", sha256="ad2ac1bf36577b1d35c4a771b4d174a06f522a1e5ef6c1f5e53a795fb624863e")
+    version("2.32.0", sha256="b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6")
+    version("2.31.0", sha256="808ecd2c11fbf2c3f9fc7a36f8c2965b343f3151011b58a1d6e7cc2e6b3cac5d")
+    version("2.25.0", sha256="8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e")
+    version("2.24.2", sha256="c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403")
+    version("2.23.0", sha256="cbdc8532537e9682f1a93ddb03440416b66906a4cc25dec3cbd73940d194bf0c")
+    version("2.22.1", sha256="75c7ee96469bb30b0c8f7edbdc4429ece4415897969f75c36173545242bc9e85")
+    version("2.21.0", sha256="da0a0bf184bb436052e3eae582defafecdb7c08cdaab7216780476e49b509755")
+    version("2.20.0", sha256="207a3d7966e75d85920569b55a19824673e8cd0b50db4c4dac2d3d52eacd7985")
+    version("2.19.1", sha256="9964bed5058e873d514bd4920951122a95963128b12f55aa199d9afbafdd5d4b")
+    version("2.18.0", sha256="d88943df0f246843a1a062796edbf709ef911de7269648eef864be259e9704e3")
+    version("2.13.0", sha256="c5ce1183b5257929fc1f1c8496239e52650707cfab24f4e0e1f1a471135b8272")
+    version("2.5.0", sha256="18ab44bc444168fd324d07f7dea94f89e056f5c5cd973e818c8783f952702e4e")
+    version("2.2.0", sha256="1a4112196497b8421480e2a0a1164071221e467853486577c4f07627a702f4c3")
+
+    variant("tools", default=False, description="Build the command line tools")
+    variant("netcdf", default=False, description="Enable GRIB to NetCDF conversion tool")
+    variant(
+        "jp2k",
+        default="openjpeg",
+        values=("openjpeg", "jasper", "none"),
+        description="Specify JPEG2000 decoding/encoding backend",
+    )
+    variant("png", default=False, description="Enable PNG support for decoding/encoding")
+    variant(
+        "aec", default=True, description="Enable Adaptive Entropy Coding for decoding/encoding"
+    )
+    variant("pthreads", default=False, description="Enable POSIX threads")
+    variant("openmp", default=False, description="Enable OpenMP threads")
+    variant(
+        "memfs", default=False, description="Enable memory based access to definitions/samples"
+    )
+    variant("fortran", default=False, description="Enable the Fortran support")
+    variant("shared", default=True, description="Build shared versions of the libraries")
+
+    variant(
+        "extra_definitions",
+        values=any_combination_of(*_definitions.keys()),
+        description="List of extra definitions to install",
+    )
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+    depends_on("fortran", type="build")  # generated
+
+    depends_on("netcdf-c", when="+netcdf")
+    # Cannot be built with openjpeg@2.0.x.
+    depends_on("openjpeg@1.5.0:1.5,2.1.0:2.3", when="jp2k=openjpeg")
+    # Additional constraint for older versions.
+    depends_on("openjpeg@:2.1", when="@:2.16 jp2k=openjpeg")
+
+    with when("jp2k=jasper"):
+        depends_on("jasper")
+        # jasper 3.x compat from commit 86f0b35f1a8492cb16f82fb976a0a5acd2986ac2
+        depends_on("jasper@:2", when="@:2.25.0")
+
+    depends_on("libpng", when="+png")
+    depends_on("libaec", when="+aec")
+    # Can be built with Python 2 or Python 3.
+    depends_on("python", when="+memfs", type="build")
+
+    depends_on("cmake@3.6:", type="build")
+    depends_on("cmake@3.12:", when="@2.19:", type="build")
+
+    depends_on("ecbuild", type="build", when="@develop")
+
+    conflicts("+openmp", when="+pthreads", msg="Cannot enable both POSIX threads and OMP")
+
+    conflicts(
+        "+netcdf",
+        when="~tools",
+        msg="Cannot enable the NetCDF conversion tool " "when the command line tools are disabled",
+    )
+
+    conflicts(
+        "~tools",
+        when="@:2.18.0",
+        msg="The command line tools can be disabled " "only starting version 2.19.0",
+    )
+
+    for center, definitions in _definitions.items():
+        kwargs = definitions.get("conflicts", None)
+        if kwargs:
+            conflicts("extra_definitions={0}".format(center), **kwargs)
+        for kwargs in definitions.get("resources", []):
+            resource(
+                name=center,
+                destination="spack-definitions",
+                placement="definitions.{0}".format(center),
+                **kwargs,
+            )
+
+    # Enforce linking against the specified JPEG2000 backend, see also
+    # https://github.com/ecmwf/eccodes/commit/2c10828495900ff3d80d1e570fe96c1df16d97fb
+    patch("openjpeg_jasper.patch", when="@:2.16")
+
+    # CMAKE_INSTALL_RPATH must be a semicolon-separated list.
+    patch("cmake_install_rpath.patch", when="@:2.10")
+
+    # Fix a bug preventing cmake from finding NetCDF:
+    patch(
+        "https://github.com/ecmwf/ecbuild/commit/3916c7d22575c45166fcc89edcbe02a6e9b81aa2.patch?full_index=1",
+        sha256="9dcc4affaaa850d4b7247baa939d0f9ffedea132369f1afc3f248dbf720386c9",
+        when="@:2.4.0+netcdf",
+    )
+
+    @when("+fortran%nag")
+    def patch(self):
+        # A number of Fortran source files assume that the kinds of integer and
+        # real variables are specified in bytes. However, the NAG compiler
+        # accepts such code only with an additional compiler flag -kind=byte.
+        # We do not simply add the flag because all user applications would
+        # have to be compiled with this flag too, which goes against one of the
+        # purposes of using the NAG compiler: make sure the code does not
+        # contradict the Fortran standards. The following logic could have been
+        # implemented as regular patch files, which would, however, be quite
+        # large. We would also have to introduce several versions of each patch
+        # file to support different versions of the package.
+
+        patch_kind_files = [
+            "fortran/eccodes_f90_head.f90",
+            "fortran/eccodes_f90_tail.f90",
+            "fortran/grib_f90_head.f90",
+            "fortran/grib_f90_tail.f90",
+            "fortran/grib_types.f90",
+        ]
+
+        patch_unix_ext_files = []
+
+        if self.run_tests:
+            patch_kind_files.extend(
+                [
+                    "examples/F90/grib_print_data.f90",
+                    "examples/F90/grib_print_data_static.f90",
+                    # Files that need patching only when the extended regression
+                    # tests are enabled, which we disable unconditionally:
+                    # 'examples/F90/bufr_attributes.f90',
+                    # 'examples/F90/bufr_expanded.f90',
+                    # 'examples/F90/bufr_get_keys.f90',
+                    # 'examples/F90/bufr_read_scatterometer.f90',
+                    # 'examples/F90/bufr_read_synop.f90',
+                    # 'examples/F90/bufr_read_temp.f90',
+                    # 'examples/F90/bufr_read_tempf.f90',
+                    # 'examples/F90/bufr_read_tropical_cyclone.f90',
+                    # 'examples/F90/grib_clone.f90',
+                    # 'examples/F90/grib_get_data.f90',
+                    # 'examples/F90/grib_nearest.f90',
+                    # 'examples/F90/grib_precision.f90',
+                    # 'examples/F90/grib_read_from_file.f90',
+                    # 'examples/F90/grib_samples.f90',
+                    # 'examples/F90/grib_set_keys.f90'
+                ]
+            )
+
+            patch_unix_ext_files.extend(
+                [
+                    "examples/F90/bufr_ecc-1284.f90",
+                    "examples/F90/grib_set_data.f90",
+                    "examples/F90/grib_set_packing.f90",
+                    # Files that need patching only when the extended regression
+                    # tests are enabled, which we disable unconditionally:
+                    # 'examples/F90/bufr_copy_data.f90',
+                    # 'examples/F90/bufr_get_string_array.f90',
+                    # 'examples/F90/bufr_keys_iterator.f90',
+                    # 'examples/F90/get_product_kind.f90',
+                    # 'examples/F90/grib_count_messages_multi.f90'
+                ]
+            )
+
+        kwargs = {"string": False, "backup": False, "ignore_absent": True}
+
+        # Return the kind and not the size:
+        filter_file(
+            r"(^\s*kind_of_double\s*=\s*)(\d{1,2})(\s*$)",
+            "\\1kind(real\\2)\\3",
+            "fortran/grib_types.f90",
+            **kwargs,
+        )
+        filter_file(
+            r"(^\s*kind_of_\w+\s*=\s*)(\d{1,2})(\s*$)",
+            "\\1kind(x\\2)\\3",
+            "fortran/grib_types.f90",
+            **kwargs,
+        )
+
+        # Replace integer kinds:
+        for size, r in [(2, 4), (4, 9), (8, 18)]:
+            filter_file(
+                r"(^\s*integer\((?:kind=)?){0}(\).*)".format(size),
+                "\\1selected_int_kind({0})\\2".format(r),
+                *patch_kind_files,
+                **kwargs,
+            )
+
+        # Replace real kinds:
+        for size, p, r in [(4, 6, 37), (8, 15, 307)]:
+            filter_file(
+                r"(^\s*real\((?:kind=)?){0}(\).*)".format(size),
+                "\\1selected_real_kind({0}, {1})\\2".format(p, r),
+                *patch_kind_files,
+                **kwargs,
+            )
+
+        # Enable getarg and exit subroutines:
+        filter_file(
+            r"(^\s*program\s+\w+)(\s*$)",
+            "\\1; use f90_unix_env; use f90_unix_proc\\2",
+            *patch_unix_ext_files,
+            **kwargs,
+        )
+
+    @property
+    def libs(self):
+        libraries = []
+
+        query_parameters = self.spec.last_query.extra_parameters
+
+        if "shared" in query_parameters:
+            shared = True
+        elif "static" in query_parameters:
+            shared = False
+        else:
+            shared = "+shared" in self.spec
+
+        # Return Fortran library if requested:
+        return_fortran = "fortran" in query_parameters
+        # Return C library if either requested or the Fortran library is not
+        # requested (to avoid overlinking) or the static libraries are
+        # requested:
+        return_c = "c" in query_parameters or not (return_fortran and shared)
+        # Return MEMFS library only if enabled and the static libraries are
+        # requested:
+        return_memfs = "+memfs" in self.spec and not shared
+
+        if return_fortran:
+            libraries.append("libeccodes_f90")
+
+        if return_c:
+            libraries.append("libeccodes")
+
+        if return_memfs:
+            libraries.append("libeccodes_memfs")
+
+        libs = find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+
+        if libs and len(libs) == len(libraries):
+            return libs
+
+        msg = "Unable to recursively locate {0} {1} libraries in {2}"
+        raise NoLibrariesError(
+            msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
+        )
+
+    def cmake_args(self):
+        jp2k = self.spec.variants["jp2k"].value
+
+        args = [
+            self.define_from_variant("ENABLE_BUILD_TOOLS", "tools"),
+            self.define_from_variant("ENABLE_NETCDF", "netcdf"),
+            self.define("ENABLE_JPG", jp2k != "none"),
+            self.define("ENABLE_JPG_LIBJASPER", jp2k == "jasper"),
+            self.define("ENABLE_JPG_LIBOPENJPEG", jp2k == "openjpeg"),
+            self.define_from_variant("ENABLE_PNG", "png"),
+            self.define_from_variant("ENABLE_AEC", "aec"),
+            self.define_from_variant("ENABLE_ECCODES_THREADS", "pthreads"),
+            self.define_from_variant("ENABLE_ECCODES_OMP_THREADS", "openmp"),
+            self.define_from_variant("ENABLE_MEMFS", "memfs"),
+            self.define(
+                "ENABLE_PYTHON{0}".format("2" if self.spec.satisfies("@2.20.0:") else ""), False
+            ),
+            self.define_from_variant("ENABLE_FORTRAN", "fortran"),
+            self.define("BUILD_SHARED_LIBS", "BOTH" if "+shared" in self.spec else "OFF"),
+            self.define("ENABLE_TESTS", self.run_tests),
+            # Examples are not installed and are just part of the test suite:
+            self.define("ENABLE_EXAMPLES", self.run_tests),
+            # Unconditionally disable the extended regression tests, since they
+            # download additional data (~134MB):
+            self.define("ENABLE_EXTRA_TESTS", False),
+        ]
+
+        if self.spec.satisfies("+netcdf"):
+            # Prevent possible overriding by environment variables NETCDF_ROOT, NETCDF_DIR, and
+            # NETCDF_PATH:
+            args.append(self.define("NETCDF_PATH", self.spec["netcdf-c"].prefix))
+            # Prevent overriding by environment variable HDF5_ROOT (starting version 2.14.0,
+            # ecCodes is shipped with ecBuild 3.1.0+, which does not seem to rely on the HDF5_ROOT
+            # variable):
+            if self.spec.satisfies("@:2.13"):
+                args.append(self.define("HDF5_ROOT", self.spec["hdf5"].prefix))
+
+        if jp2k == "openjpeg":
+            args.append(self.define("OPENJPEG_PATH", self.spec["openjpeg"].prefix))
+
+        if self.spec.satisfies("+png"):
+            args.append(self.define("ZLIB_ROOT", self.spec["zlib-api"].prefix))
+
+        if self.spec.satisfies("+aec"):
+            # Prevent overriding by environment variables AEC_DIR and AEC_PATH:
+            args.append(self.define("AEC_DIR", self.spec["libaec"].prefix))
+
+        return args
+
+    @run_after("install")
+    def install_extra_definitions(self):
+        for center in self.spec.variants["extra_definitions"].value:
+            if center != "none":
+                center_dir = "definitions.{0}".format(center)
+                install_tree(
+                    join_path(self.stage.source_path, "spack-definitions", center_dir),
+                    join_path(self.prefix.share.eccodes, center_dir),
+                )
+
+    def check(self):
+        # https://confluence.ecmwf.int/display/ECC/ecCodes+installation
+        with working_dir(self.build_directory):
+            ctest()

--- a/recipes/fdb/5.17/repo/packages/eckit/package.py
+++ b/recipes/fdb/5.17/repo/packages/eckit/package.py
@@ -1,0 +1,217 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class Eckit(CMakePackage):
+    """ecKit is a cross-platform c++ toolkit that supports development of tools
+    and applications at ECMWF."""
+
+    homepage = "https://github.com/ecmwf/eckit"
+    git = "https://github.com/ecmwf/eckit.git"
+    url = "https://github.com/ecmwf/eckit/archive/refs/tags/1.16.0.tar.gz"
+
+    maintainers("skosukhin", "climbfuji", "victoria-cherkas", "dominichofer")
+
+    license("Apache-2.0")
+
+    version("1.28.8", sha256="4bd4fbb971ec9b53a64d47f40336c130b37349850ae82114d5c04f393ea70d23")
+    version("1.28.3", sha256="24b2b8d9869849a646aa3fd9d95e4181a92358cd837d95b22e25d718a6ad7738")
+    version("1.27.0", sha256="499f3f8c9aec8d3f42369e3ceedc98b2b09ac04993cfd38dfdf7d38931703fe7")
+    version("1.25.2", sha256="a611d26d50a9f2133b75100567a890eb0e0a48a96669b8c8475baf9d6f359397")
+    version("1.24.5", sha256="2fd74e04c20a59f9e13635828d9da880e18f8a2cb7fd3bfd0201e07071d6ec41")
+    version("1.24.4", sha256="b6129eb4f7b8532aa6905033e4cf7d09aadc8547c225780fea3db196e34e4671")
+    version("1.23.1", sha256="cd3c4b7a3a2de0f4a59f00f7bab3178dd59c0e27900d48eaeb357975e8ce2f15")
+    version("1.23.0", sha256="3cac55ddf7036ecd32cb0974a1ec3a2d347de574ab3a2c0bb6c6f8982e5a7a09")
+    version("1.22.1", sha256="a3463d07e47e3bd3e5efa13fdc03d7d3a30ada919ccec3259c6c9c7da4cfdfd9")
+    version("1.20.2", sha256="9c11ddaaf346e40d11312b81ca7f1b510017f26618f4c0f5c5c59c37623fbac8")
+    version("1.19.0", sha256="a5fef36b4058f2f0aac8daf5bcc9740565f68da7357ddd242de3a5eed4765cc7")
+    version("1.16.3", sha256="d2aae7d8030e2ce39e5d04e36dd6aa739f3c8dfffe32c61c2a3127c36b573485")
+    version("1.16.0", sha256="9e09161ea6955df693d3c9ac70131985eaf7cf24a9fa4d6263661c6814ebbaf1")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo"),
+    )
+
+    variant("tools", default=True, description="Build the command line tools")
+    variant("mpi", default=True, description="Enable MPI support")
+    variant("openmp", default=True, description="Enable OpenMP support")
+    variant("admin", default=True, description="Build utilities for administration tools")
+    variant("sql", default=True, description="Build SQL engine")
+    variant(
+        "linalg",
+        values=any_combination_of("eigen", "armadillo", "mkl", "lapack"),
+        description="List of supported linear algebra backends",
+    )
+    variant(
+        "compression",
+        values=any_combination_of("bzip2", "snappy", "lz4", "aec"),
+        description="List of supported compression backends",
+    )
+    variant("xxhash", default=True, description="Enable xxHash support for hashing")
+    variant("ssl", default=False, description="Enable MD4 and SHA1 support with OpenSSL")
+    variant("curl", default=False, description="Enable URL data transferring with cURL")
+    variant("jemalloc", default=False, description="Link against jemalloc memory allocator")
+    variant(
+        "unicode",
+        default=True,
+        description="Enable support for Unicode characters in Yaml/JSON" "parsers",
+    )
+    variant("aio", default=True, description="Enable asynchronous IO")
+    variant("fismahigh", default=False, description="Apply patching for FISMA-high compliance")
+
+    # Build issues with cmake 3.20, not sure about 3.21
+    depends_on("cmake@3.12:3.19,3.22:", type="build")
+    depends_on("ecbuild@3.5:", when="@:1.20.99", type="build")
+    depends_on("ecbuild@3.7:", when="@1.21:", type="build")
+
+    depends_on("mpi", when="+mpi")
+    depends_on("llvm-openmp", when="+openmp %apple-clang", type=("build", "run"))
+
+    depends_on("yacc", type="build", when="+admin")
+    depends_on("flex", type="build", when="+admin")
+    depends_on("ncurses", when="+admin")
+
+    depends_on("yacc", type="build", when="+sql")
+    depends_on("flex", type="build", when="+sql")
+
+    depends_on("eigen", when="linalg=eigen")
+    depends_on("armadillo", when="linalg=armadillo")
+    depends_on("mkl", when="linalg=mkl")
+    depends_on("lapack", when="linalg=lapack")
+
+    depends_on("bzip2", when="compression=bzip2")
+    depends_on("snappy", when="compression=snappy")
+    depends_on("lz4", when="compression=lz4")
+    depends_on("libaec", when="compression=aec")
+
+    depends_on("openssl", when="+ssl")
+
+    depends_on("curl", when="+curl")
+
+    depends_on("jemalloc", when="+jemalloc")
+
+    # The package enables LAPACK backend (together with MKL backend)
+    # when='linalg=mkl'. This leads to two identical installations when:
+    #   eckit linalg=mkl
+    #   eckit linalg=mkl,lapack
+    # We prevent that by introducing the following conflict:
+    conflicts(
+        "linalg=lapack",
+        when="linalg=mkl",
+        msg='"linalg=lapack" is implied when "linalg=mkl" and '
+        "must not be specified additionally",
+    )
+
+    def cmake_args(self):
+        args = [
+            # Some features that we want to build are experimental:
+            self.define("ENABLE_EXPERIMENTAL", self._enable_experimental),
+            self.define_from_variant("ENABLE_BUILD_TOOLS", "tools"),
+            # We let ecBuild find the MPI library. We could help it by setting
+            # CMAKE_C_COMPILER to mpicc but that might give CMake a wrong
+            # impression that no additional flags are needed to link to
+            # libpthread, which will lead to problems with libraries that are
+            # linked with the C++ compiler. We could additionally set
+            # CMAKE_CXX_COMPILER to mpicxx. That would solve the problem with
+            # libpthread but lead to overlinking to MPI libraries, which we
+            # currently prefer to avoid since ecBuild does the job in all known
+            # cases.
+            self.define_from_variant("ENABLE_MPI", "mpi"),
+            self.define_from_variant("ENABLE_OMP", "openmp"),
+            self.define_from_variant("ENABLE_ECKIT_CMD", "admin"),
+            self.define_from_variant("ENABLE_ECKIT_SQL", "sql"),
+            self.define("ENABLE_EIGEN", "linalg=eigen" in self.spec),
+            self.define("ENABLE_ARMADILLO", "linalg=armadillo" in self.spec),
+            self.define("ENABLE_MKL", "linalg=mkl" in self.spec),
+            self.define("ENABLE_BZIP2", "compression=bzip2" in self.spec),
+            self.define("ENABLE_SNAPPY", "compression=snappy" in self.spec),
+            self.define("ENABLE_LZ4", "compression=lz4" in self.spec),
+            self.define("ENABLE_AEC", "compression=aec" in self.spec),
+            self.define_from_variant("ENABLE_XXHASH", "xxhash"),
+            self.define_from_variant("ENABLE_SSL", "ssl"),
+            self.define_from_variant("ENABLE_CURL", "curl"),
+            self.define_from_variant("ENABLE_JEMALLOC", "jemalloc"),
+            self.define_from_variant("ENABLE_UNICODE", "unicode"),
+            self.define_from_variant("ENABLE_AIO", "aio"),
+            self.define("ENABLE_TESTS", self.run_tests),
+            # Unconditionally disable additional unit/performance tests, since
+            # they download additional data (~1.6GB):
+            self.define("ENABLE_EXTRA_TESTS", False),
+            # No reason to check for doxygen and generate the documentation
+            # since it is not installed:
+            self.define("ENABLE_DOCS", False),
+            # Disable features that are currently not needed:
+            self.define("ENABLE_CUDA", False),
+            self.define("ENABLE_VIENNACL", False),
+            # Ceph/Rados storage support requires https://github.com/ceph/ceph
+            # and will be added later:
+            self.define("ENABLE_RADOS", False),
+            # rsync support requires https://github.com/librsync/librsync and
+            # will be added later:
+            self.define("ENABLE_RSYNC", False),
+            # Disable "prototyping code that may never see the light of day":
+            self.define("ENABLE_SANDBOX", False),
+        ]
+
+        # Static build of eckit not working, many places in eckit's build
+        # system have SHARED hardcoded (in several CMakeLists.txt files).
+        args.append("-DBUILD_SHARED_LIBS=ON")
+
+        if "linalg=mkl" not in self.spec:
+            # ENABLE_LAPACK is ignored if MKL backend is enabled
+            # (the LAPACK backend is still built though):
+            args.append(self.define("ENABLE_LAPACK", "linalg=lapack" in self.spec))
+
+        if "+admin" in self.spec and "+termlib" in self.spec["ncurses"]:
+            # Make sure that libeckit_cmd is linked to a library that resolves 'setupterm',
+            # 'tputs', etc. That is either libncurses (when 'ncurses~termlib') or libtinfo (when
+            # 'ncurses+termlib'). CMake considers the latter only if CURSES_NEED_NCURSES is set to
+            # TRUE. Note that the installation of eckit does not fail without this but the building
+            # of a dependent package (e.g. fdb) might fail due to the undefined references.
+            args.append(self.define("CURSES_NEED_NCURSES", True))
+
+        return args
+
+    def setup_build_environment(self, env):
+        # Bug fix for macOS - cmake's find_package doesn't add "libtinfo.dylib" to the
+        # ncurses libraries, but the ncurses pkgconfig explicitly sets it. We need to
+        # add the correct spec['ncurses'].libs.ld_flags to LDFLAGS to compile eckit
+        # when the admin variant is enabled.
+        if self.spec.satisfies("platform=darwin") and self.spec.satisfies("+admin"):
+            env.append_flags("LDFLAGS", self.spec["ncurses"].libs.ld_flags)
+
+    def check(self):
+        ctest_args = ["-j", str(make_jobs)]
+
+        broken_tests = []
+        if self._enable_experimental:
+            # The following test quasi-randomly fails not because it reveals a bug in the library
+            # but because its implementation has a bug (static initialization order fiasco):
+            broken_tests.append("eckit_test_experimental_singleton_singleton")
+
+        if broken_tests:
+            ctest_args.extend(["-E", "|".join(broken_tests)])
+
+        with working_dir(self.build_directory):
+            ctest(*ctest_args)
+
+    @property
+    def _enable_experimental(self):
+        return "linalg=armadillo" in self.spec
+
+    @when("+fismahigh")
+    def patch(self):
+        if os.path.exists(".travis.yml"):
+            os.remove(".travis.yml")

--- a/recipes/fdb/5.17/repo/packages/fdb/metkit_1.7.0.patch
+++ b/recipes/fdb/5.17/repo/packages/fdb/metkit_1.7.0.patch
@@ -1,0 +1,11 @@
+--- a/src/fdb5/tools/fdb-hammer.cc
++++ b/src/fdb5/tools/fdb-hammer.cc
+@@ -22,7 +22,7 @@
+ #include "eckit/option/SimpleOption.h"
+ #include "eckit/option/VectorOption.h"
+ 
+-#include "metkit/grib/GribHandle.h"
++#include "metkit/codes/GribHandle.h"
+ 
+ #include "fdb5/grib/GribArchiver.h"
+ #include "fdb5/io/HandleGatherer.h"

--- a/recipes/fdb/5.17/repo/packages/fdb/package.py
+++ b/recipes/fdb/5.17/repo/packages/fdb/package.py
@@ -1,0 +1,98 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Fdb(CMakePackage):
+    """FDB (Fields DataBase) is a domain-specific object store developed at
+    ECMWF for storing, indexing and retrieving GRIB data."""
+
+    homepage = "https://github.com/ecmwf/fdb"
+    url = "https://github.com/ecmwf/fdb/archive/refs/tags/5.7.8.tar.gz"
+    git = "https://github.com/ecmwf/fdb.git"
+
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
+
+    license("Apache-2.0")
+
+    version("master", branch="master")
+    version("5.17.3", sha256="b477f95a00bd0177e26490e0d0911679aba9183c53ac525625fe1665487068d0")
+    version("5.16.2", sha256="1014c85f7bd6f406f9abd04d0f5bd5bd757c17a1556dd6e49e0288bf455da12a")
+    version("5.13.106", sha256="34c7ee498f7511f5255ffcfd94bee51264c6e4892063e2c2a172f2a4fd86062d")
+    version("5.11.23", sha256="09b1d93f2b71d70c7b69472dfbd45a7da0257211f5505b5fcaf55bfc28ca6c65")
+    version("5.11.17", sha256="375c6893c7c60f6fdd666d2abaccb2558667bd450100817c0e1072708ad5591e")
+    version("5.10.8", sha256="6a0db8f98e13c035098dd6ea2d7559f883664cbf9cba8143749539122ac46099")
+    version("5.7.8", sha256="6adac23c0d1de54aafb3c663d077b85d0f804724596623b381ff15ea4a835f60")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
+    variant("tools", default=True, description="Build the command line tools")
+    variant(
+        "backends",
+        values=any_combination_of(
+            # FDB backend in indexed filesystem with table-of-contents with
+            # additional support for Lustre filesystem stripping control:
+            "lustre",
+            # Backends that will be added later:
+            # FDB backend in persistent memory (NVRAM):
+            # 'pmem',  # (requires https://github.com/ecmwf/pmem)
+            # FDB backend in CEPH object store (using Rados):
+            # 'rados'  # (requires eckit with RADOS support)
+        ),
+        description="List of supported backends",
+    )
+
+    depends_on("cmake@3.12:", type="build")
+    depends_on("ecbuild@3.4:", type="build")
+    depends_on("ecbuild@3.7:", type="build", when="@5.11.6:")
+
+    depends_on("eckit@1.16:")
+    depends_on("eckit@1.24.4:", when="@5.11.22:")
+    depends_on("eckit+admin", when="+tools")
+
+    depends_on("eccodes@2.10:")
+    depends_on("eccodes+tools", when="+tools")
+
+    depends_on("metkit@1.5:+grib")
+
+    depends_on("lustre", when="backends=lustre")
+
+    # Starting version 1.7.0, metkit installs GribHandle.h to another directory.
+    # That is accounted for only starting version 5.8.0:
+    patch("metkit_1.7.0.patch", when="@:5.7.10+tools^metkit@1.7.0:")
+
+    # Download test data before running a test:
+    patch(
+        "https://github.com/ecmwf/fdb/commit/86e06b60f9a2d76a389a5f49bedd566d4c2ad2b2.patch?full_index=1",
+        sha256="8b4bf3a473ec86fd4d7672faa7d74292dde443719299f2ba59a2c8501d6f0906",
+        when="@5.7.1:5.7.10+tools",
+    )
+
+    @property
+    def libs(self):
+        return find_libraries("libfdb5", root=self.prefix, shared=True, recursive=True)
+
+    def cmake_args(self):
+        enable_build_tools = "+tools" in self.spec
+
+        args = [
+            self.define("ENABLE_FDB_BUILD_TOOLS", enable_build_tools),
+            self.define("ENABLE_BUILD_TOOLS", enable_build_tools),
+            # We cannot disable the FDB backend in indexed filesystem with
+            # table-of-contents because some default test programs and tools
+            # cannot be built without it:
+            self.define("ENABLE_TOCFDB", True),
+            self.define("ENABLE_LUSTRE", "backends=lustre" in self.spec),
+            self.define("ENABLE_PMEMFDB", False),
+            self.define("ENABLE_RADOSFDB", False),
+            # The tests download additional data (~10MB):
+            self.define("ENABLE_TESTS", self.run_tests),
+            # We do not need any experimental features:
+            self.define("ENABLE_EXPERIMENTAL", False),
+            self.define("ENABLE_SANDBOX", False),
+        ]
+        return args

--- a/recipes/fdb/5.17/repo/packages/gribjump/package.py
+++ b/recipes/fdb/5.17/repo/packages/gribjump/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Gribjump(CMakePackage):
+    """GribJump is a C++ library for extracting subsets of data from GRIB files, 
+    particularly data archived in the FDB
+    """
+
+    homepage = "https://github.com/ecmwf/gribjump"
+    url = "https://github.com/ecmwf/gribjump/archive/refs/tags/0.10.0.tar.gz"
+    git = "https://github.com/ecmwf/fdb.git"
+
+    maintainers("cosunae")
+
+    license("Apache-2.0")
+
+    version("0.10.0", sha256="04a6c7322e585acb7e432e74d68f073ab584a42af9dcb2b4b97f17aebf17d07f")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
+    depends_on("cmake@3.12:", type="build")
+    depends_on("ecbuild", type="build")
+    depends_on("eckit")
+    depends_on("eccodes")
+    depends_on("fdb")
+    depends_on("metkit")
+    depends_on("libaec@1.1.1:")
+
+    def cmake_args(self):
+        args = [
+            self.define("ENABLE_MEMFS", True),
+            self.define("ENABLE_ECCODES_THREADS", True),
+            self.define("ENABLE_AEC", True),
+        ]
+        return args

--- a/recipes/fdb/5.17/repo/packages/libaec/package.py
+++ b/recipes/fdb/5.17/repo/packages/libaec/package.py
@@ -1,0 +1,61 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Libaec(CMakePackage):
+    """Libaec provides fast lossless compression of 1 up to 32 bit wide signed
+    or unsigned integers (samples). It implements Golomb-Rice compression
+    method under the BSD license and includes a free drop-in replacement for
+    the SZIP library.
+    """
+
+    homepage = "https://gitlab.dkrz.de/k202009/libaec"
+    url = "https://gitlab.dkrz.de/api/v4/projects/k202009%2Flibaec/repository/archive.tar.gz?sha=v1.0.2"
+    list_url = "https://gitlab.dkrz.de/k202009/libaec/tags"
+
+    provides("szip")
+
+    license("BSD-2-Clause")
+
+    version("1.1.4", sha256="95439e861968cb0638a10b0bbdb37c9a10df1b22c5ee0293902acdbc68140f53")
+    version("1.1.3", sha256="453de44eb6ea2500843a4cf4d2e97d1be251d2df7beae6c2ebe374edcb11e378")
+    version("1.1.2", sha256="dc03ddbc9dabf806af1036e2c7bde44bbb1a2a6e0b186d46a6ca06390622afb9")
+    version("1.1.1", sha256="7be8e9b9a508fc165896fd7d85274666ac09e5a01be4f7de9fef5317065e13d4")
+    version("1.0.6", sha256="abab8c237d85c982bb4d6bde9b03c1f3d611dcacbd58bca55afac2496d61d4be")
+    version("1.0.5", sha256="7bf7be828dc3caefcc968e98a59b997b6b3b06e4123137e9e0b0988dc1be3b2f")
+    version("1.0.4", sha256="7456adff4e817f94fc57a3eca824db1c203770ffb7a9253c435093ac5e239e31")
+    version("1.0.3", sha256="c28b340b20dcc0ad352970143e01718bd68dd5ef2a07a971736368805972f562")
+    version("1.0.2", sha256="b9e5bbbc8bf9cbfd3b9b4ce38b3311f2c88d3d99f476edb35590eb0006aa1fc5")
+    version("1.0.1", sha256="3668eb4ed36724441e488a7aadc197426afef4b1e8bd139af6d3e36023906459")
+    version("1.0.0", sha256="849f08b08ddaaffe543d06d0ced5e4ee3e526b13a67c5f422d126b1c9cf1b546")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build")  # generated
+
+    variant("shared", default=True, description="Builds a shared version of the library")
+
+    @property
+    def libs(self):
+        query = self.spec.last_query
+        libraries = ["libaec"]
+
+        if "szip" == query.name or "szip" in query.extra_parameters:
+            libraries.insert(0, "libsz")
+
+        shared = "~shared" not in self.spec
+
+        libs = find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+
+        if not libs:
+            msg = "Unable to recursively locate {0} {1} libraries in {2}"
+            raise spack.error.NoLibrariesError(
+                msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
+            )
+        return libs
+
+    def cmake_args(self):
+        return [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]

--- a/recipes/fdb/5.17/repo/packages/metkit/package.py
+++ b/recipes/fdb/5.17/repo/packages/metkit/package.py
@@ -1,0 +1,68 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Metkit(CMakePackage):
+    """Toolkit for manipulating and describing meteorological objects,
+    implementing the MARS language and associated processing and semantics."""
+
+    homepage = "https://github.com/ecmwf/metkit"
+    git = "https://github.com/ecmwf/metkit.git"
+    url = "https://github.com/ecmwf/metkit/archive/refs/tags/1.7.0.tar.gz"
+
+    maintainers("skosukhin", "victoria-cherkas", "dominichofer")
+
+    license("Apache-2.0")
+
+    version("1.11.22", sha256="e2a2ea1532f9e187e37b807dbf35cd09325b2aef29bd5117203d57ba2e65a0d6")
+    version("1.11.5", sha256="717e0d92499d7a1b49338c3762d829aa83c75f8095dc9e7cdc7f49c209bb847b")
+    version("1.10.17", sha256="1c525891d77ed28cd4c87b065ba4d1aea24d0905452c18d885ccbd567bbfc9b1")
+    version("1.10.2", sha256="a038050962aecffda27b755c40b0a6ed0db04a2c22cad3d8c93e6109c8ab4b34")
+    version("1.9.2", sha256="35d5f67196197cc06e5c2afc6d1354981e7c85a441df79a2fbd774e0c343b0b4")
+    version("1.7.0", sha256="8c34f6d8ea5381bd1bcfb22462349d03e1592e67d8137e76b3cecf134a9d338c")
+
+
+    depends_on("cxx", type="build")  # generated
+
+    variant("tools", default=True, description="Build the command line tools")
+    variant("grib", default=True, description="Enable support for GRIB format")
+    variant("odb", default=False, description="Enable support for ODB data")
+
+    depends_on("cmake@3.12:", type="build")
+    depends_on("ecbuild@3.4:", type="build")
+
+    depends_on("eckit@1.16:")
+    depends_on("eckit@1.21:", when="@1.10:")
+    depends_on("eckit@:1.21", when="@:1.10")
+
+    depends_on("eccodes@2.5:", when="+grib")
+    depends_on("eccodes@2.27:", when="@1.10.2: +grib")
+
+    depends_on("odc", when="+odb")
+
+    conflicts(
+        "+tools",
+        when="~grib~odb",
+        msg="None of the command line tools is built when both "
+        "GRIB format and ODB data support are disabled",
+    )
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("ENABLE_BUILD_TOOLS", "tools"),
+            self.define_from_variant("ENABLE_GRIB", "grib"),
+            self.define_from_variant("ENABLE_ODC", "odb"),
+            # The tests download additional data (~4KB):
+            self.define("ENABLE_TESTS", self.run_tests),
+            # The library does not really implement support for BUFR format:
+            self.define("ENABLE_BUFR", False),
+            # The library does not really implement support for NetCDF format:
+            self.define("ENABLE_NETCDF", False),
+            # We do not need any experimental features:
+            self.define("ENABLE_EXPERIMENTAL", False),
+        ]
+        return args


### PR DESCRIPTION
Changes:

1. Upgraded FDB to version 5.17.3
2. Enabled the GRIBJUMP plugin by setting the required environment variables: ( FDB_ENABLE_GRIBJUMP, AUTO_LOAD_PLUGINS, ECKIT_HOME)