### PR TITLE
[fdb] add kaleido py dep for plot renderings

### DIFF
--- a/recipes/fdb/5.17/meta/private/pyproject.toml
+++ b/recipes/fdb/5.17/meta/private/pyproject.toml
@@ -21,6 +21,7 @@ earthkit-data = ">=0.16.3"
 pygribjump = { git = "https://github.com/ecmwf/gribjump.git", tag = "0.10.0" }
 nbconvert = "*"
 pyyaml = "*"
+kaleido = "^1.1.0"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]


### PR DESCRIPTION
Without this dependency the plots in the notebooks (https://github.com/MeteoSwiss/nwp-fdb-polytope-demo/blob/three_new_feature_extraction_notebooks/notebooks/Polytope/feature_time_series.ipynb) are not rendered 