### PR TITLE
[fdb] add kaleido python dependencies for notebooks plots

### DIFF
--- a/recipes/fdb/5.17/meta/private/pyproject.toml
+++ b/recipes/fdb/5.17/meta/private/pyproject.toml
@@ -19,10 +19,10 @@ earthkit-geo = "*"
 earthkit-meteo = "*"
 earthkit-data = ">=0.16.3"
 pygribjump = { git = "https://github.com/ecmwf/gribjump.git", tag = "0.10.0" }
-polytope-client = "0.7.8"
+polytope-client = "^0.7.8"
 nbconvert = "*"
 pyyaml = "*"
-kaleido = "0.2.1"
+kaleido = "^0.2.1"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]


### PR DESCRIPTION
Add `kaleido` python dependency. Otherwise we cannot produce the plots in PNG and only interactive plots are not rendered in HTML. 