### PR TITLE
[fdb] Pin kaleido to 0.2.1

### DIFF
--- a/recipes/fdb/5.18/meta/private/pyproject.toml
+++ b/recipes/fdb/5.18/meta/private/pyproject.toml
@@ -22,7 +22,7 @@ pygribjump = { git = "https://github.com/ecmwf/gribjump.git", tag = "0.10.2" }
 polytope-client = "^0.7.8"
 nbconvert = "*"
 pyyaml = "*"
-kaleido = "^1.1.0"
+kaleido = "0.2.1"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]


### PR DESCRIPTION
Have to pin the version because all other versions `^0.2.1` or `^1.1.0` raises `ChromeNotFoundError` with:
```
chart.show("png")
---------------------------------------------------------------------------
ChromeNotFoundError                       Traceback (most recent call last)
ChromeNotFoundError: 

The above exception was the direct cause of the following exception:

ChromeNotFoundError                       Traceback (most recent call last)
File /user-environment/venvs/fdb/lib/python3.11/site-packages/plotly/io/_kaleido.py:398, in to_image(fig, format, width, height, scale, validate, engine)
    388     height = (
    389         height
    390         or fig_dict.get("layout", {}).get("height")
   (...)    395         or defaults.default_height
    396     )
--> 398     img_bytes = kaleido.calc_fig_sync(
    399         fig_dict,
    400         opts=dict(
    401             format=format or defaults.default_format,
    402             width=width,
    403             height=height,
    404             scale=scale or defaults.default_scale,
    405         ),
    406         topojson=defaults.topojson,
    407         kopts=kopts,
    408     )
    409 except ChromeNotFoundError:
...
or install it from your terminal by running:

    $ plotly_get_chrome
```