### PR TITLE
Add depends_on c to metkit package.py

### DIFF
--- a/recipes/fdb/5.18/repo/packages/metkit/package.py
+++ b/recipes/fdb/5.18/repo/packages/metkit/package.py
@@ -36,6 +36,7 @@ class Metkit(CMakePackage):
     version("1.7.0", sha256="8c34f6d8ea5381bd1bcfb22462349d03e1592e67d8137e76b3cecf134a9d338c")
 
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")  # generated
 
     variant("tools", default=True, description="Build the command line tools")


### PR DESCRIPTION
Bumping from Spack v0.23 to v1.1 resulted in an error asking me to introduce pretty much exactly this line. 

Adding this line to the package.py fixed the build using v1.1, and didn't break the build using v0.23.

Therefore, I figure merging shouldn't be a problem.