### PR TITLE
fdb: add ICON grid support changes from ECMWF hackathon

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,12 +5,12 @@ clusters:
         uarch: 'a100'
         partition: 'normal'
         variables:
-          F7T_URL: 'https://api.cscs.ch/mch/firecrest/v1'
+          F7T_URL: 'https://api.cscs.ch/mch/firecrest/v2'
       -
         uarch: 'zen3'
         partition: 'postproc'
         variables:
-          F7T_URL: 'https://api.cscs.ch/mch/firecrest/v1'
+          F7T_URL: 'https://api.cscs.ch/mch/firecrest/v2'
           SLURM_EXCLUSIVE: ''
           SLURM_NODES: '1'
           SLURM_CPU_BIND: 'none'

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ UENV_CIBUILDV_GIT_CONFIG_VALUE_0=git@gitlab.dkrz.de:
 UENV_CIBUILDV_GIT_CONFIG_KEY_0=url.https://${NAME}:${TOKEN}@gitlab.dkrz.de/.insteadOf
 ```
 
+
 The `NAME` is specific to the git provider:
 
 | provider | `NAME`           |

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -8,9 +8,9 @@ fdb:
   specs:
   - fdb@=5.18.3 backends=lustre
   - gribjump@=0.10.2
-  - eckit@git.feature/iconch linalg=none compression=lz4 +curl +ssl
+  - eckit@git.feature/eckit-geo linalg=none compression=lz4 +curl +ssl
   - metkit@=1.15.2-levelist
-  - eccodes@=git.develop jp2k=none ~fortran +pthreads +aec +geo
+  - eccodes@=git.feature/eckit-geo jp2k=none ~fortran +pthreads +aec +geo
   - ecbuild@=3.12.0
   - python@=3.11.6
   variants:

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -8,9 +8,9 @@ fdb:
   specs:
   - fdb@=5.18.3 backends=lustre
   - gribjump@=0.10.2
-  - eckit@=1.32.3 linalg=none
+  - eckit@git.feature/iconch linalg=none compression=lz4 +curl +ssl
   - metkit@=1.15.2-levelist
-  - eccodes@=2.39.5 jp2k=none ~fortran +pthreads +aec
+  - eccodes@=git.develop jp2k=none ~fortran +pthreads +aec +geo
   - ecbuild@=3.12.0
   - python@=3.11.6
   variants:

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -10,7 +10,7 @@ fdb:
   - gribjump@=0.10.2
   - eckit@git.feature/eckit-geo linalg=none compression=lz4 +curl +ssl
   - metkit@=1.15.2-levelist
-  - eccodes@=git.feature/eckit-geo jp2k=none ~fortran +pthreads +aec +geo
+  - eccodes@=git.feature/eckit-geo jp2k=none ~fortran +pthreads +aec +native
   - ecbuild@=3.12.0
   - python@=3.11.6
   variants:

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -6,15 +6,15 @@ fdb:
   mpi: null
   packages: []
   specs:
-  - fdb@=5.18.3 backends=lustre
-  - gribjump@=0.10.2
-  - eckit@git.feature/eckit-geo linalg=none compression=lz4 +curl +ssl
-  - metkit@=1.15.2-levelist
-  - eccodes@=git.feature/eckit-geo jp2k=none ~fortran +pthreads +aec +geo
-  - ecbuild@=3.12.0
-  - python@=3.11.6
+    - fdb@=5.18.3 backends=lustre
+    - gribjump@=0.10.2
+    - eckit@=native linalg=none compression=lz4 +curl +ssl
+    - metkit@=1.15.2-levelist
+    - eccodes@=native jp2k=none ~fortran +pthreads +aec +geo
+    - ecbuild@=3.12.0
+    - python@=3.11.6
   variants:
-  - ~mpi
+    - ~mpi
   views:
     realtime:
       link: roots

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -10,7 +10,7 @@ fdb:
   - gribjump@=0.10.2
   - eckit@git.feature/eckit-geo linalg=none compression=lz4 +curl +ssl
   - metkit@=1.15.2-levelist
-  - eccodes@=git.feature/eckit-geo jp2k=none ~fortran +pthreads +aec +native
+  - eccodes@=git.feature/eckit-geo jp2k=none ~fortran +pthreads +aec +geo
   - ecbuild@=3.12.0
   - python@=3.11.6
   variants:

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -6,7 +6,7 @@ fdb:
   mpi: null
   packages: []
   specs:
-    - fdb@=5.19.1 backends=lustre
+    - fdb@=5.19.2 backends=lustre
     - gribjump@=0.10.3
     - eckit@=2.0.2 linalg=none compression=lz4 +curl +ssl
     - metkit@=1.16.3-levelist

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -8,10 +8,10 @@ fdb:
   specs:
     - fdb@=5.18.3 backends=lustre
     - gribjump@=0.10.2
-    - eckit@=native linalg=none compression=lz4 +curl +ssl
-    - metkit@=1.15.2-levelist
-    - eccodes@=native jp2k=none ~fortran +pthreads +aec +geo
-    - ecbuild@=3.12.0
+    - eckit@=2.0.1 linalg=none compression=lz4 +curl +ssl
+    - metkit@=levelist
+    - eccodes@=2.46.0 jp2k=none ~fortran +pthreads +aec +geo
+    - ecbuild@=3.13.1
     - python@=3.11.6
   variants:
     - ~mpi

--- a/recipes/fdb/5.18/environments.yaml
+++ b/recipes/fdb/5.18/environments.yaml
@@ -6,10 +6,10 @@ fdb:
   mpi: null
   packages: []
   specs:
-    - fdb@=5.18.3 backends=lustre
-    - gribjump@=0.10.2
-    - eckit@=2.0.1 linalg=none compression=lz4 +curl +ssl
-    - metkit@=levelist
+    - fdb@=5.19.1 backends=lustre
+    - gribjump@=0.10.3
+    - eckit@=2.0.2 linalg=none compression=lz4 +curl +ssl
+    - metkit@=1.16.3-levelist
     - eccodes@=2.46.0 jp2k=none ~fortran +pthreads +aec +geo
     - ecbuild@=3.13.1
     - python@=3.11.6

--- a/recipes/fdb/5.18/post-install
+++ b/recipes/fdb/5.18/post-install
@@ -1,4 +1,5 @@
 #!/bin/bash
+# test
 # Post-install for the uenv:
 #  - Fetch eccodes/GRIB shared definitions
 #  - Install Poetry and create a venv for FDB tooling

--- a/recipes/fdb/5.18/repo/packages/ecbuild/package.py
+++ b/recipes/fdb/5.18/repo/packages/ecbuild/package.py
@@ -17,6 +17,8 @@ class Ecbuild(CMakePackage):
 
     license("Apache-2.0")
 
+    version("3.13.1", sha256="9759815aef22c9154589ea025056db086c575af9dac635614b561ab825f9477e")
+    version("3.13.0", sha256="7be83510e7209c61273121bcf817780597c3afa41a5129bfccc281f0df1ffda1")
     version("3.12.0", sha256="70c7fc9b17f736a3312167c2c36d13b3b5833a255fe2b168b2886ad7c743ffdf")
     version("3.11.0", sha256="38a96bdeb38feb65446b6f95b35492232abd188c41b8a28fd128f9f88e00b05d")
     version("3.10.0", sha256="7065e1725584b507517cbfc456299ff588e20adf37bc6210ce89fb65a1ad08d0") 

--- a/recipes/fdb/5.18/repo/packages/eccodes/package.py
+++ b/recipes/fdb/5.18/repo/packages/eccodes/package.py
@@ -99,9 +99,12 @@ class Eccodes(CMakePackage):
         description="List of extra definitions to install",
     )
 
+    variant("geo", default=False, description="Enable eckit::geo")
+
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
+    depends_on("eckit", when="+geo")
 
     depends_on("netcdf-c", when="+netcdf")
     # Cannot be built with openjpeg@2.0.x.
@@ -325,6 +328,7 @@ class Eccodes(CMakePackage):
             self.define_from_variant("ENABLE_ECCODES_THREADS", "pthreads"),
             self.define_from_variant("ENABLE_ECCODES_OMP_THREADS", "openmp"),
             self.define_from_variant("ENABLE_MEMFS", "memfs"),
+            self.define_from_variant("ENABLE_ECKIT_GEO", "geo"),
             self.define(
                 "ENABLE_PYTHON{0}".format("2" if self.spec.satisfies("@2.20.0:") else ""), False
             ),

--- a/recipes/fdb/5.18/repo/packages/eccodes/package.py
+++ b/recipes/fdb/5.18/repo/packages/eccodes/package.py
@@ -101,12 +101,12 @@ class Eccodes(CMakePackage):
         description="List of extra definitions to install",
     )
 
-    variant("geo", default=False, description="Enable eckit::geo")
+    variant("native", default=False, description="Enable eckit::geo")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
-    depends_on("eckit", when="+geo")
+    depends_on("eckit", when="+native")
 
     depends_on("netcdf-c", when="+netcdf")
     # Cannot be built with openjpeg@2.0.x.
@@ -330,8 +330,8 @@ class Eccodes(CMakePackage):
             self.define_from_variant("ENABLE_ECCODES_THREADS", "pthreads"),
             self.define_from_variant("ENABLE_ECCODES_OMP_THREADS", "openmp"),
             self.define_from_variant("ENABLE_MEMFS", "memfs"),
-            self.define_from_variant("ENABLE_ECKIT_GEO", "geo"),
-            self.define_from_variant("ENABLE_GEOGRAPHY", "geo"),
+            self.define_from_variant("ENABLE_ECKIT_GEO", "native"),
+            self.define_from_variant("ENABLE_GEOGRAPHY", "native"),
             self.define(
                 "ENABLE_PYTHON{0}".format("2" if self.spec.satisfies("@2.20.0:") else ""), False
             ),

--- a/recipes/fdb/5.18/repo/packages/eccodes/package.py
+++ b/recipes/fdb/5.18/repo/packages/eccodes/package.py
@@ -49,6 +49,7 @@ class Eccodes(CMakePackage):
     license("Apache-2.0")
 
     version("develop", branch="develop")
+    version("native", branch="feature/eckit-geo")
 
     version("2.45.0", sha256="6c84b39d7cc5e3b8330eeabe880f3e337f9b2ee1ebce20ea03eecd785f6c39a1")
     version("2.44.0", sha256="c75fb1f91b765b6b8b4774632a8a6fbcec96934db015fb63c2ad2560aedd443b")

--- a/recipes/fdb/5.18/repo/packages/eccodes/package.py
+++ b/recipes/fdb/5.18/repo/packages/eccodes/package.py
@@ -101,12 +101,12 @@ class Eccodes(CMakePackage):
         description="List of extra definitions to install",
     )
 
-    variant("native", default=False, description="Enable eckit::geo")
+    variant("geo", default=False, description="Enable eckit::geo")
 
     depends_on("c", type="build")  # generated
     depends_on("cxx", type="build")  # generated
     depends_on("fortran", type="build")  # generated
-    depends_on("eckit", when="+native")
+    depends_on("eckit", when="+geo")
 
     depends_on("netcdf-c", when="+netcdf")
     # Cannot be built with openjpeg@2.0.x.
@@ -330,8 +330,8 @@ class Eccodes(CMakePackage):
             self.define_from_variant("ENABLE_ECCODES_THREADS", "pthreads"),
             self.define_from_variant("ENABLE_ECCODES_OMP_THREADS", "openmp"),
             self.define_from_variant("ENABLE_MEMFS", "memfs"),
-            self.define_from_variant("ENABLE_ECKIT_GEO", "native"),
-            self.define_from_variant("ENABLE_GEOGRAPHY", "native"),
+            self.define_from_variant("ENABLE_ECKIT_GEO", "geo"),
+            self.define_from_variant("ENABLE_GEOGRAPHY", "geo"),
             self.define(
                 "ENABLE_PYTHON{0}".format("2" if self.spec.satisfies("@2.20.0:") else ""), False
             ),

--- a/recipes/fdb/5.18/repo/packages/eccodes/package.py
+++ b/recipes/fdb/5.18/repo/packages/eccodes/package.py
@@ -50,6 +50,8 @@ class Eccodes(CMakePackage):
 
     version("develop", branch="develop")
 
+    version("2.45.0", sha256="6c84b39d7cc5e3b8330eeabe880f3e337f9b2ee1ebce20ea03eecd785f6c39a1")
+    version("2.44.0", sha256="c75fb1f91b765b6b8b4774632a8a6fbcec96934db015fb63c2ad2560aedd443b")
     version("2.42.0", sha256="60371b357cb011dee546db2eabace5b7e27f0f87d3ea4a5adde7891371b3c128")
     version("2.39.5", git="https://github.com/ecmwf/eccodes.git", tag="2.39.5")
     version("2.39.0", sha256="0c4d746700acc49af9c878925f1b26bdd42443ff7c2d7c676deb2babb6847afb")
@@ -329,6 +331,7 @@ class Eccodes(CMakePackage):
             self.define_from_variant("ENABLE_ECCODES_OMP_THREADS", "openmp"),
             self.define_from_variant("ENABLE_MEMFS", "memfs"),
             self.define_from_variant("ENABLE_ECKIT_GEO", "geo"),
+            self.define_from_variant("ENABLE_GEOGRAPHY", "geo"),
             self.define(
                 "ENABLE_PYTHON{0}".format("2" if self.spec.satisfies("@2.20.0:") else ""), False
             ),

--- a/recipes/fdb/5.18/repo/packages/eccodes/package.py
+++ b/recipes/fdb/5.18/repo/packages/eccodes/package.py
@@ -49,8 +49,8 @@ class Eccodes(CMakePackage):
     license("Apache-2.0")
 
     version("develop", branch="develop")
-    version("native", branch="feature/eckit-geo")
 
+    version("2.46.0", sha256="7d959253d5e34aeb16caa14d4889ac06486d19821216743142733a32ee7b4935")
     version("2.45.0", sha256="6c84b39d7cc5e3b8330eeabe880f3e337f9b2ee1ebce20ea03eecd785f6c39a1")
     version("2.44.0", sha256="c75fb1f91b765b6b8b4774632a8a6fbcec96934db015fb63c2ad2560aedd443b")
     version("2.42.0", sha256="60371b357cb011dee546db2eabace5b7e27f0f87d3ea4a5adde7891371b3c128")
@@ -331,8 +331,8 @@ class Eccodes(CMakePackage):
             self.define_from_variant("ENABLE_ECCODES_THREADS", "pthreads"),
             self.define_from_variant("ENABLE_ECCODES_OMP_THREADS", "openmp"),
             self.define_from_variant("ENABLE_MEMFS", "memfs"),
-            self.define_from_variant("ENABLE_ECKIT_GEO", "geo"),
             self.define_from_variant("ENABLE_GEOGRAPHY", "geo"),
+            self.define_from_variant("ENABLE_ECKIT_GEO", "geo"),
             self.define(
                 "ENABLE_PYTHON{0}".format("2" if self.spec.satisfies("@2.20.0:") else ""), False
             ),

--- a/recipes/fdb/5.18/repo/packages/eckit/package.py
+++ b/recipes/fdb/5.18/repo/packages/eckit/package.py
@@ -21,6 +21,8 @@ class Eckit(CMakePackage):
 
     license("Apache-2.0")
 
+    version("native", branch="feature/eckit-geo")
+
     version("1.33.1", sha256="89878eb491fbc22c99b88f5b2a1521e1e3fe4b3779b0254ce3e11929a48cea74")
     version("1.33.0", sha256="a15f89df0cdaa2d8a74843a1e72a7b3b304958a4fe119b51eec5efadbf113d4f")
     version("1.32.3", sha256="33e0fac2656cdd2f2d877dbfe7a4751ee657ab732c00dd90bd48a406298a100f")

--- a/recipes/fdb/5.18/repo/packages/eckit/package.py
+++ b/recipes/fdb/5.18/repo/packages/eckit/package.py
@@ -13,13 +13,16 @@ class Eckit(CMakePackage):
     and applications at ECMWF."""
 
     homepage = "https://github.com/ecmwf/eckit"
-    git = "https://github.com/ecmwf/eckit.git"
     url = "https://github.com/ecmwf/eckit/archive/refs/tags/1.16.0.tar.gz"
+    git = "https://github.com/ecmwf/eckit.git"
+    list_url = "https://github.com/ecmwf/eckit/tags"
 
     maintainers("skosukhin", "climbfuji", "victoria-cherkas", "dominichofer")
 
     license("Apache-2.0")
 
+    version("1.33.1", sha256="89878eb491fbc22c99b88f5b2a1521e1e3fe4b3779b0254ce3e11929a48cea74")
+    version("1.33.0", sha256="a15f89df0cdaa2d8a74843a1e72a7b3b304958a4fe119b51eec5efadbf113d4f")
     version("1.32.3", sha256="33e0fac2656cdd2f2d877dbfe7a4751ee657ab732c00dd90bd48a406298a100f")
     version("1.32.2", sha256="f2940e99f1550119497418221e4c5073eb9c3ea776b15a4f56236ef4438a1210")
     version("1.31.4", sha256="045ebd9aaecf2773dc8c82f4226022776576cb0d911a76f8d1d069c97e9530c8")

--- a/recipes/fdb/5.18/repo/packages/eckit/package.py
+++ b/recipes/fdb/5.18/repo/packages/eckit/package.py
@@ -21,8 +21,8 @@ class Eckit(CMakePackage):
 
     license("Apache-2.0")
 
-    version("native", branch="feature/eckit-geo")
-
+    version("2.0.1", sha256="bbb305af0894c5139b0b2170dcec088c78c84b608da006baa9d8e0ece5f21cb0")
+    version("2.0.0", sha256="172e6e1226b61db44d9095e70d45612eb0887ce82bc1077d4f02200355334749")
     version("1.33.1", sha256="89878eb491fbc22c99b88f5b2a1521e1e3fe4b3779b0254ce3e11929a48cea74")
     version("1.33.0", sha256="a15f89df0cdaa2d8a74843a1e72a7b3b304958a4fe119b51eec5efadbf113d4f")
     version("1.32.3", sha256="33e0fac2656cdd2f2d877dbfe7a4751ee657ab732c00dd90bd48a406298a100f")

--- a/recipes/fdb/5.18/repo/packages/eckit/package.py
+++ b/recipes/fdb/5.18/repo/packages/eckit/package.py
@@ -21,6 +21,7 @@ class Eckit(CMakePackage):
 
     license("Apache-2.0")
 
+    version("2.0.2", sha256="46b9c1f90e0b565698c5c79c54676401d33738ec82995c025d5d5aabeb13ad2b")
     version("2.0.1", sha256="bbb305af0894c5139b0b2170dcec088c78c84b608da006baa9d8e0ece5f21cb0")
     version("2.0.0", sha256="172e6e1226b61db44d9095e70d45612eb0887ce82bc1077d4f02200355334749")
     version("1.33.1", sha256="89878eb491fbc22c99b88f5b2a1521e1e3fe4b3779b0254ce3e11929a48cea74")

--- a/recipes/fdb/5.18/repo/packages/fdb/package.py
+++ b/recipes/fdb/5.18/repo/packages/fdb/package.py
@@ -20,6 +20,7 @@ class Fdb(CMakePackage):
     license("Apache-2.0")
 
     version("master", branch="master")
+    version("5.19.2", sha256="7dfffd7279a53431fe11a82b5c6dcc94f42bc5100a0ff925fe0b54de94d1cfe2")
     version("5.19.1", sha256="de5edddd4c17cb4ddfe61bfed60a6b37408d5ed92a2d19a493592e1abfe65a8d")
     version("5.19.0", sha256="1275c4b89dcdfcb342a255e22a7d500070d5d32251910c4c2a10d5734c0590eb")
     version("5.18.3", sha256="8b6fff6c32923bd8e456f2ec1540b171b4efdbf92e81ae2e5ff2967dec224a86")

--- a/recipes/fdb/5.18/repo/packages/fdb/package.py
+++ b/recipes/fdb/5.18/repo/packages/fdb/package.py
@@ -13,12 +13,15 @@ class Fdb(CMakePackage):
     homepage = "https://github.com/ecmwf/fdb"
     url = "https://github.com/ecmwf/fdb/archive/refs/tags/5.7.8.tar.gz"
     git = "https://github.com/ecmwf/fdb.git"
+    list_url = "https://github.com/ecmwf/fdb/tags"
 
     maintainers("skosukhin", "victoria-cherkas", "dominichofer")
 
     license("Apache-2.0")
 
     version("master", branch="master")
+    version("5.19.1", sha256="de5edddd4c17cb4ddfe61bfed60a6b37408d5ed92a2d19a493592e1abfe65a8d")
+    version("5.19.0", sha256="1275c4b89dcdfcb342a255e22a7d500070d5d32251910c4c2a10d5734c0590eb")
     version("5.18.3", sha256="8b6fff6c32923bd8e456f2ec1540b171b4efdbf92e81ae2e5ff2967dec224a86")
     version("5.18.0", sha256="d72c7180b9c0e3048a19bc60df6f2827e7849dea8299b7d3f21d5ffb7fc99951")
     version("5.17.3", sha256="b477f95a00bd0177e26490e0d0911679aba9183c53ac525625fe1665487068d0")

--- a/recipes/fdb/5.18/repo/packages/gribjump/package.py
+++ b/recipes/fdb/5.18/repo/packages/gribjump/package.py
@@ -14,10 +14,14 @@ class Gribjump(CMakePackage):
     homepage = "https://github.com/ecmwf/gribjump"
     url = "https://github.com/ecmwf/gribjump/archive/refs/tags/0.10.0.tar.gz"
     git = "https://github.com/ecmwf/gribjump.git"
+    list_url = "https://github.com/ecmwf/gribjump/tags"
+    
 
     maintainers("cosunae")
 
     license("Apache-2.0")
+    version("0.10.3", sha256="8001f8a0e4b03664134ea42612d22d6499e098d2063b12182030986895689f6c")
+    version("0.10.2", sha256="c1635c1f902daa244592b60c9b1a81375b467409635bd2cbfc6993d32554bd3d")
     version("0.10.2", sha256="c1635c1f902daa244592b60c9b1a81375b467409635bd2cbfc6993d32554bd3d")
     version("0.10.0", sha256="04a6c7322e585acb7e432e74d68f073ab584a42af9dcb2b4b97f17aebf17d07f")
 

--- a/recipes/fdb/5.18/repo/packages/metkit/package.py
+++ b/recipes/fdb/5.18/repo/packages/metkit/package.py
@@ -19,9 +19,8 @@ class Metkit(CMakePackage):
 
     license("Apache-2.0")
 
-    # As of 04.03.2026, the levelist branch has been rebased on top of v1.16.2
-    version("levelist", branch="levelist")
-
+    version("1.16.3-levelist", sha256="90bd8ca8be1c954f8d6af44b5a416c7357a37bcc9247fa3cdec8ec5cb7c411d0")
+    version("1.16.3", sha256="b2da2ce50aac68365506c7fb8661889df61a01e53ca7e8f699fe9d3015d44974")
     version("1.16.2", sha256="30a65a2cc14942e7ce64ea5539a1b6b85ecce336811014aba70e1f4f9e651f68")
     version("1.16.1", sha256="0520cba65afeaede6553c8b62941e67c0f88123602e19d0898538a52e2b0f522")
     version("1.16.0", sha256="7b93e4fc1608c1ac205fbf3e094d50ba8a88e7223b65eab7a12362f55550c8e1")
@@ -30,11 +29,11 @@ class Metkit(CMakePackage):
         "1.15.2-levelist",
         sha256="25cebe7610949848671131ee3681e3e7e01d376e7b74e1a269872b9fba15ab54",
     )
-    version(
-        "9999.99",
-        sha256="d63181aecd6e3128609145e381b214b81b79072b414313351e7d3914377eda13",
-        url="https://github.com/ecmwf/metkit/archive/refs/tags/levelist-double.tar.gz",
-    )
+    #version(
+        #"999.999.999",
+        #sha256="d63181aecd6e3128609145e381b214b81b79072b414313351e7d3914377eda13",
+        #url="https://github.com/ecmwf/metkit/archive/refs/tags/levelist-double.tar.gz",
+    #)
     version("1.14.1", sha256="996cc1d4b569c73b20490bfccbd8ee09d78a94dd9c15e643528d7d9a360f3d2e")
     version("1.11.22", sha256="e2a2ea1532f9e187e37b807dbf35cd09325b2aef29bd5117203d57ba2e65a0d6")
     version("1.11.5", sha256="717e0d92499d7a1b49338c3762d829aa83c75f8095dc9e7cdc7f49c209bb847b")

--- a/recipes/fdb/5.18/repo/packages/metkit/package.py
+++ b/recipes/fdb/5.18/repo/packages/metkit/package.py
@@ -19,6 +19,7 @@ class Metkit(CMakePackage):
 
     license("Apache-2.0")
 
+    version("1.17.0", sha256="0fb4cae8cf440f6589b426cbddf8fd37434bc59e178b34df6b7633bfdbb47de3")
     version("1.16.3-levelist", sha256="90bd8ca8be1c954f8d6af44b5a416c7357a37bcc9247fa3cdec8ec5cb7c411d0")
     version("1.16.3", sha256="b2da2ce50aac68365506c7fb8661889df61a01e53ca7e8f699fe9d3015d44974")
     version("1.16.2", sha256="30a65a2cc14942e7ce64ea5539a1b6b85ecce336811014aba70e1f4f9e651f68")

--- a/recipes/fdb/5.18/repo/packages/metkit/package.py
+++ b/recipes/fdb/5.18/repo/packages/metkit/package.py
@@ -11,13 +11,18 @@ class Metkit(CMakePackage):
     implementing the MARS language and associated processing and semantics."""
 
     homepage = "https://github.com/ecmwf/metkit"
-    git = "https://github.com/ecmwf/metkit.git"
     url = "https://github.com/ecmwf/metkit/archive/refs/tags/1.7.0.tar.gz"
+    git = "https://github.com/ecmwf/metkit.git"
+    list_url = "https://github.com/ecmwf/metkit/tags"
 
     maintainers("skosukhin", "victoria-cherkas", "dominichofer")
 
     license("Apache-2.0")
 
+    version("1.16.2", sha256="30a65a2cc14942e7ce64ea5539a1b6b85ecce336811014aba70e1f4f9e651f68")
+    version("1.16.1", sha256="0520cba65afeaede6553c8b62941e67c0f88123602e19d0898538a52e2b0f522")
+    version("1.16.0", sha256="7b93e4fc1608c1ac205fbf3e094d50ba8a88e7223b65eab7a12362f55550c8e1")
+    version("1.15.9", sha256="19e656fdafd52375d076303f710bfb71d24298866960e479082d7cb8c730efee")
     version(
         "1.15.2-levelist",
         sha256="25cebe7610949848671131ee3681e3e7e01d376e7b74e1a269872b9fba15ab54",

--- a/recipes/fdb/5.18/repo/packages/metkit/package.py
+++ b/recipes/fdb/5.18/repo/packages/metkit/package.py
@@ -19,6 +19,9 @@ class Metkit(CMakePackage):
 
     license("Apache-2.0")
 
+    # As of 04.03.2026, the levelist branch has been rebased on top of v1.16.2
+    version("levelist", branch="levelist")
+
     version("1.16.2", sha256="30a65a2cc14942e7ce64ea5539a1b6b85ecce336811014aba70e1f4f9e651f68")
     version("1.16.1", sha256="0520cba65afeaede6553c8b62941e67c0f88123602e19d0898538a52e2b0f522")
     version("1.16.0", sha256="7b93e4fc1608c1ac205fbf3e094d50ba8a88e7223b65eab7a12362f55550c8e1")


### PR DESCRIPTION
Copies the changes to the ecCodes Spack package definition to this repository from the draft PR opened during the ECMWF hackathon end of October 2025.

The changes have been tested using ecCodes version 2.39.5, and appear to be working without any issue until now:
```shell
❯ grib_ls /home/lmeinen/work/icon-ch1-eps-202602111200-0-t_2m-perturb.grib2 
/home/lmeinen/work/icon-ch1-eps-202602111200-0-t_2m-perturb.grib2
edition      centre       date         dataType     gridType     stepRange    typeOfLevel  level        shortName    packingType  
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
2            lssw         20260211     cp           unstructured_grid  0m           heightAboveGround  2            2t           grid_simple 
10 of 10 messages in /home/lmeinen/work/icon-ch1-eps-202602111200-0-t_2m-perturb.grib2
``` 

See also: https://github.com/MeteoSwiss/nwp_polytope/pull/187

cscs-ci run alps;system=balfrin;uarch=zen3;uenv=fdb:5.18