### PR TITLE
[fdb] Update covjsonkit version to 0.2.19

### DIFF
--- a/recipes/fdb/5.19/meta/private/pyproject.toml
+++ b/recipes/fdb/5.19/meta/private/pyproject.toml
@@ -24,7 +24,7 @@ nbconvert = "*"
 nbformat = "*"
 pyyaml = "*"
 kaleido = "0.2.1"
-covjsonkit = "^0.2.14"
+covjsonkit = "^0.2.19"
 
 # Earthkit 1.0 release candidates
 earthkit-utils = "~1.0.0rc1"


### PR DESCRIPTION
0.2.19 fixes a bug where parameters with shortName 't' didn't populate the data axes of xarray datastructures properly.